### PR TITLE
Facilitator Access Fixes

### DIFF
--- a/attendees.php
+++ b/attendees.php
@@ -81,7 +81,11 @@ require_course_login($course);
 
 // Actions the user can perform.
 $capability_checker = new custom_capability_checker();
-$canviewattendees = $capability_checker->manager_permissions; //custom LOL capability checking system
+$canviewattendees = (
+    //custom LOL capability checking system
+    $capability_checker->manager_permissions ||
+    has_capability('mod/facetoface:viewattendees', $context)
+);
 
 $cantakeattendance = has_capability('mod/facetoface:takeattendance', $context);
 $canviewcancellations = has_capability('mod/facetoface:viewcancellations', $context);
@@ -91,12 +95,12 @@ $canapproverequests = false;
 //GCHLOL - PB - add capability check add attendees and add my attendees
 
 
-$can_add_attendees = $capability_checker->manager_permissions; //custom LOL capability checking system
+$can_add_attendees = (
+    //custom LOL capability checking system
+    $capability_checker->manager_permissions ||
+    has_capability('mod/facetoface:addattendees', $context)
+);
 $can_add_my_attendees = $capability_checker->manager_permissions; //custom LOL capability checking system
-/*
-$can_add_attendees = has_capability('mod/facetoface:addattendees', $context);
-$can_add_my_attendees = has_capability('mod/facetoface:addmyattendees', $context);
-*/
 
 
 $requests = array();
@@ -104,10 +108,10 @@ $declines = array();
 
 // If a user can take attendance, they can approve staff's booking requests.
 // GCHLOL: PB Change to if they can add attendees
-if ($can_add_attendees) {
-    $requests = facetoface_get_requests($session->id);
-}
-if ($can_add_my_attendees) {
+if (
+    $can_add_attendees ||
+    $can_add_my_attendees
+) {
     $requests = facetoface_get_requests($session->id);
 }
 
@@ -341,7 +345,7 @@ if ($canviewattendees || $cantakeattendance) {
     if (!$takeattendance) {
         if ($capability_checker->manager_permissions ||
             has_capability('mod/facetoface:addattendees', $context) ||
-            has_capability('mod/facetoface:removeattendees', $context) || 
+            has_capability('mod/facetoface:removeattendees', $context) ||
 			has_capability('mod/facetoface:addmyattendees', $context) ||
             has_capability('mod/facetoface:removemyattendees', $context)) {
 

--- a/classes/custom_capability_checker.php
+++ b/classes/custom_capability_checker.php
@@ -48,6 +48,8 @@ class custom_capability_checker{
     private function getViewPermissions(){
         global $USER, $DB;
 
+        $joins = $wheres = $params = [];
+
         [
             'joins' => $myusersjoins,
             'where' => $myuserswhere,

--- a/editattendees.php
+++ b/editattendees.php
@@ -29,7 +29,7 @@
  */
 
 use mod_facetoface\custom_capability_checker;
-use moodle_exception;
+
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 require_once('lib.php');
 

--- a/editattendees.php
+++ b/editattendees.php
@@ -60,12 +60,14 @@ if (!$cm = get_coursemodule_from_instance('facetoface', $facetoface->id, $course
 // Check essential permissions.
 require_course_login($course);
 $context = context_course::instance($course->id);
-//require_capability('mod/facetoface:viewattendees', $context);
 
 $capability_checker = new custom_capability_checker();
 $manager_permissions = $capability_checker->manager_permissions;
 
-if(!$manager_permissions){
+if(
+    !$manager_permissions &&
+    !has_capability('mod/facetoface:viewattendees', $context)
+) {
     throw new moodle_exception('error:nopermissiontoeditattendees', 'mod_facetoface');
 }
 

--- a/editattendees.php
+++ b/editattendees.php
@@ -66,7 +66,7 @@ $capability_checker = new custom_capability_checker();
 $manager_permissions = $capability_checker->manager_permissions;
 
 if(!$manager_permissions){
-    throw new moodle_exception('', "mod_facetoface", '', "You do not have permission to do this");
+    throw new moodle_exception('error:nopermissiontoeditattendees', 'mod_facetoface');
 }
 
 

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -183,6 +183,7 @@ $string['error:manageremailaddressmissing'] = 'You are currently not assigned to
 $string['error:mustspecifycoursemodulefacetoface'] = 'Must specify a course module or a Face-to-Face ID';
 $string['error:nomanageremail'] = 'You didn\'t provide an email address for your manager';
 $string['error:nomanagersemailset'] = 'No manager email is set';
+$string['error:nopermissiontoeditattendees'] = 'You don\'t have permission to edit attendees for this Face-to-Face session.';
 $string['error:nopermissiontosignup'] = 'You don\'t have permission to signup to this Face-to-Face session.';
 $string['error:noticeidincorrect'] = 'Notice ID is incorrect: {$a}';
 $string['error:problemsigningup'] = 'There was a problem signing you up.';

--- a/view.php
+++ b/view.php
@@ -155,7 +155,11 @@ function print_session_list($courseid, $facetofaceid, $location) {
     $context = context_course::instance($courseid);
 
     $capability_checker = new custom_capability_checker();
-    $viewattendees = $capability_checker->manager_permissions; //custom LOL capability checking system
+    $viewattendees = (
+        //custom LOL capability checking system
+        $capability_checker->manager_permissions ||
+        has_capability('mod/facetoface:viewattendees', $context)
+    );
 
     $editsessions = has_capability('mod/facetoface:editsessions', $context);
     $deletesessions = has_capability('mod/facetoface:deletesessions', $context); // GCHLOL - MF - Delete permission


### PR DESCRIPTION
Primarily adds some fallback capability checks to those that were changed to use `custom_capability_checker` to retain existing facilitator access to manage attendees.
Also fixes a few errors and oddities I noticed.