### PR TITLE
Empty Profile Field Matching

### DIFF
--- a/classes/data/user_sql.php
+++ b/classes/data/user_sql.php
@@ -84,7 +84,10 @@ class user_sql {
         ";
 
         $where = "
-            aa.data = ab.data or
+            (
+                ab.data > 1 and
+                aa.data = ab.data
+            ) or
             (
                 ae.data > 1 and
                 aa.data = ae.data


### PR DESCRIPTION
Additional check to prevent matching on empty profile field values.
Fixes case where users with an empty "Reports To" field could be shown under the "Potential Attendees" list for managers with an empty "Position ID" field.