### PR TITLE
Printable Attendance Sheet

### DIFF
--- a/attendance_sheet.php
+++ b/attendance_sheet.php
@@ -51,9 +51,11 @@ $data->course_name = $course->fullname;
 $data->instance_name = $instance->name;
 
 $data->logo_url = null;
-$logo_url = $OUTPUT->get_logo_url(null, 100);
-if ($logo_url) {
-    $data->logo_url = $logo_url->out(false);
+if ($instance->attendancesheetshowlogo) {
+    $logo_url = $OUTPUT->get_logo_url(null, 100);
+    if ($logo_url) {
+        $data->logo_url = $logo_url->out(false);
+    }
 }
 
 // Session Date

--- a/attendance_sheet.php
+++ b/attendance_sheet.php
@@ -1,0 +1,161 @@
+<?php
+
+use mod_facetoface\custom_capability_checker;
+use tool_organisation\persistent\position;
+
+require(__DIR__ . '/../../config.php');
+require_once("$CFG->dirroot/mod/facetoface/lib.php");
+
+$session_id = required_param('session', PARAM_INT);
+
+$session = facetoface_get_session($session_id);
+if (!$session) {
+    throw new moodle_exception('error:incorrectcoursemodulesession', 'facetoface');
+}
+
+$instance = $DB->get_record('facetoface', [ 'id' => $session->facetoface ]);
+if (!$instance) {
+    throw new moodle_exception('error:incorrectfacetofaceid', 'facetoface');
+}
+
+$course = $DB->get_record('course', [ 'id' => $instance->course ]);
+if (!$course) {
+    throw new moodle_exception('error:coursemisconfigured', 'facetoface');
+}
+
+$cm = get_coursemodule_from_instance('facetoface', $instance->id, $course->id);
+if (!$cm) {
+    throw new moodle_exception('error:incorrectcoursemodule', 'facetoface');
+}
+
+// Page Meta
+$PAGE->set_url('/mod/facetoface/attendance_sheet.php', [ 'session' => $session->id ]);
+require_course_login($course);
+
+$context = context_course::instance($course->id);
+
+$capability_checker = new custom_capability_checker();
+$can_view = (
+    $capability_checker->manager_permissions ||
+    has_capability('mod/facetoface:viewattendees', $context)
+);
+if (!$can_view) {
+    $error_url = new moodle_url('/mod/facetoface/view.php', [ 'id' => $cm->id ]);
+
+    throw new moodle_exception('nopermissions', '', $error_url->out(false), get_string('view'));
+}
+
+// Page Data
+$data = new stdClass();
+$data->course_name = $course->fullname;
+$data->instance_name = $instance->name;
+
+$data->logo_url = null;
+$logo_url = $OUTPUT->get_logo_url(null, 100);
+if ($logo_url) {
+    $data->logo_url = $logo_url->out(false);
+}
+
+// Session Date
+$data->session_date = null;
+if ($session->datetimeknown) {
+    $session_dates = [];
+    foreach ($session->sessiondates as $date) {
+        $date_data = facetoface_format_session_times($date->timestart, $date->timefinish, null);
+
+        $session_lang_key = !empty($sessionobj->timezone) ? 'sessionstartdateandtime' : 'sessionstartdateandtimewithouttimezone';
+        if ($date_data->startdate !== $date_data->enddate) {
+            $session_lang_key = !empty($sessionobj->timezone) ? 'sessionstartfinishdateandtime' : 'sessionstartfinishdateandtimewithouttimezone';
+        }
+
+        $session_dates[] = get_string($session_lang_key, 'facetoface', $date_data);
+    }
+
+    $data->session_date = implode(html_writer::empty_tag('br'), $session_dates);
+}
+
+// Custom Fields
+$data->custom_fields = [];
+$custom_fields = facetoface_get_session_customfields();
+$custom_field_data = facetoface_get_customfielddata($session->id);
+foreach ($custom_fields as $field) {
+    if (empty($custom_field_data[$field->shortname])) {
+        continue;
+    }
+
+    $field_data = $custom_field_data[$field->shortname]->data;
+    $formatted_data = format_string($field_data);
+
+    if ($field->type === CUSTOMFIELD_TYPE_MULTISELECT) {
+        $values = explode(CUSTOMFIELD_DELIMITER, $formatted_data);
+        $formatted_data = implode(', ', $values);
+    }
+
+    $data->custom_fields[] = (object)[
+        'name' => format_string($field->name),
+        'value' => $formatted_data,
+    ];
+}
+
+// Trainers
+$data->trainers = [];
+$trainer_roles = facetoface_get_trainer_roles();
+if ($trainer_roles) {
+    $trainers = facetoface_get_trainers($session->id) ?: [];
+
+    foreach ($trainers as $role_id => $role_trainers) {
+        if (!isset($trainer_roles[$role_id])) {
+            continue;
+        }
+
+        $trainer_role = $trainer_roles[$role_id];
+        $trainer_names = [];
+        foreach ($role_trainers as $trainer) {
+            $trainer_names[] = fullname($trainer);
+        }
+
+        if (!empty($trainer_names)) {
+            $data->trainers[] = (object)[
+                'role' => $trainer_role->name,
+                'names' => implode(', ', $trainer_names),
+            ];
+        }
+    }
+}
+
+// Attendees
+$ignored_statuses = [ MDL_F2F_STATUS_BOOKED ];
+$data->attendees = [];
+$attendees = facetoface_get_attendees($session->id);
+foreach ($attendees as $attendee) {
+    $user = $DB->get_record('user', [ 'id' => $attendee->id ]);
+
+    $status = '';
+    if (!in_array($attendee->statuscode, $ignored_statuses)) {
+        $status_key = facetoface_get_status($attendee->statuscode);
+        $status = get_string("status_$status_key", 'facetoface');
+    }
+
+    $position_names = [];
+    $positions = position::get_positions_by_userid($user->id);
+    foreach ($positions as $position) {
+        $position_names[] = $position->get('name');
+    }
+
+    $positions_output = implode(', ', $position_names);
+
+    $data->attendees[] = (object)[
+        'username' => $user->username,
+        'name' => fullname($user),
+        'position' => $positions_output,
+        'status' => $status,
+    ];
+}
+
+// Rendering
+$content = $OUTPUT->render_from_template('mod_facetoface/attendance_sheet', $data);
+
+echo $OUTPUT->render_from_template('mod_facetoface/print', [
+    'title' => get_string('attendancesheet:heading', 'facetoface'),
+    'page' => $content,
+]);

--- a/attendance_sheet.php
+++ b/attendance_sheet.php
@@ -1,6 +1,12 @@
 <?php
 
 use mod_facetoface\custom_capability_checker;
+use mod_facetoface\enum\attendance_column;
+use mod_facetoface\util\enum_util;
+use tool_organisation\persistent\assignment;
+use tool_organisation\persistent\hierarchy;
+use tool_organisation\persistent\level;
+use tool_organisation\persistent\level_data;
 use tool_organisation\persistent\position;
 
 require(__DIR__ . '/../../config.php');
@@ -57,6 +63,8 @@ if ($instance->attendancesheetshowlogo) {
         $data->logo_url = $logo_url->out(false);
     }
 }
+
+// region Details Table
 
 // Session Date
 $data->session_date = null;
@@ -124,34 +132,176 @@ if ($trainer_roles) {
     }
 }
 
+// endregion
+
+// region Attendees Table
+
+// Headings
+// Apply reasonable defaults if not configured.
+$configured_columns = [
+    attendance_column::NAME,
+    attendance_column::USERNAME,
+    attendance_column::POSITION,
+];
+// Specifically check isset and not empty string to allow only name (0) to be configured.
+if (
+    isset($instance->attendancesheetcolumns) &&
+    $instance->attendancesheetcolumns !== ''
+) {
+    $configured_columns = explode(',', $instance->attendancesheetcolumns);
+}
+
+$column_options = enum_util::menu_options(attendance_column::class);
+$data->headings = [];
+foreach ($configured_columns as $column_key) {
+    if (isset($column_options[$column_key])) {
+        $data->headings[] = (object)[
+            'key' => $column_key,
+            'label' => $column_options[$column_key],
+        ];
+    }
+}
+
 // Attendees
 $ignored_statuses = [ MDL_F2F_STATUS_BOOKED ];
-$data->attendees = [];
 $attendees = facetoface_get_attendees($session->id);
+
+$unit_hierarchy_id = null;
+if (in_array(attendance_column::UNIT, $configured_columns)) {
+    $unit_hierarchy = hierarchy::get_record([ 'idnumber' => 'unit' ], MUST_EXIST);
+    $unit_hierarchy_id = $unit_hierarchy->get('id');
+}
+
+$user_paypoints = [];
+if (
+    !empty($attendees) &&
+    array_intersect(
+        $configured_columns,
+        [
+            attendance_column::STREAM,
+            attendance_column::PAYPOINT,
+        ]
+    )
+) {
+    [ $users_sql, $users_params ] = $DB->get_in_or_equal(array_column($attendees, 'id'));
+
+    $paypoint_records = $DB->get_records_sql(
+        "
+            select  assignment.id as assignment_id,
+                    level.id,
+                    level.name,
+                    assignment.userid as user_id
+            from    {" . assignment::TABLE . "} assignment
+                    join {" . level_data::TABLE . "} level_data on
+                        level_data.assignid = assignment.id
+                    join {" . level::TABLE . "} level on
+                        level.id = level_data.levelid
+                    join {" . hierarchy::TABLE . "} hierarchy on
+                        hierarchy.id = level.hierarchyid
+            where   assignment.userid $users_sql and
+                    hierarchy.idnumber = 'paypoint'
+        ",
+        $users_params
+    );
+
+    foreach ($paypoint_records as $record) {
+        $user_id = $record->user_id;
+        if (!isset($user_paypoints[$user_id])) {
+            $user_paypoints[$user_id] = [];
+        }
+
+        $user_paypoints[$user_id][] = $record;
+    }
+}
+
+$data->attendees = [];
 foreach ($attendees as $attendee) {
     $user = $DB->get_record('user', [ 'id' => $attendee->id ]);
+
+    $column_data = [];
+    foreach ($configured_columns as $column_key) {
+        switch ($column_key) {
+            case attendance_column::NAME:
+                $column_data[] = fullname($user);
+
+                break;
+
+            case attendance_column::USERNAME:
+                $column_data[] = $user->username;
+
+                break;
+
+            case attendance_column::EMAIL:
+                $column_data[] = $user->email;
+
+                break;
+
+            case attendance_column::UNIT:
+                $unit_names = [];
+                $positions = position::get_positions_by_userid($user->id);
+                foreach ($positions as $position) {
+                    $level_data_items = $position->get_level_data();
+                    foreach ($level_data_items as $level_data) {
+                        $level = level::get_record([
+                            'id' => $level_data->get('levelid'),
+                            'hierarchyid' => $unit_hierarchy->get('id'),
+                        ]);
+
+                        if ($level) {
+                            $unit_names[] = $level->get('name');
+                        }
+                    }
+                }
+
+                $column_data[] = implode(', ', array_unique($unit_names));
+
+                break;
+
+            case attendance_column::POSITION:
+                $position_names = [];
+                $positions = position::get_positions_by_userid($user->id);
+                foreach ($positions as $position) {
+                    $position_names[] = $position->get('name');
+                }
+
+                $column_data[] = implode(', ', array_unique($position_names));
+
+                break;
+
+            case attendance_column::STREAM:
+            case attendance_column::PAYPOINT:
+                $paypoints = $user_paypoints[$user->id] ?? [];
+                if ($column_key == attendance_column::PAYPOINT) {
+                    $column_data[] = implode(', ', array_unique(array_column($paypoints, 'name')));
+
+                    break;
+                }
+
+                $stream_names = [];
+                foreach ($paypoints as $paypoint) {
+                    $level = new level($paypoint->id);
+                    $stream_level = $level->get_parent_level()->get_parent_level();
+
+                    $stream_names[] = $stream_level->get('name');
+                }
+
+                $column_data[] = implode(', ', array_unique($stream_names));
+
+                break;
+        }
+    }
 
     $status = '';
     if (!in_array($attendee->statuscode, $ignored_statuses)) {
         $status_key = facetoface_get_status($attendee->statuscode);
         $status = get_string("status_$status_key", 'facetoface');
     }
+    $column_data[] = $status;
 
-    $position_names = [];
-    $positions = position::get_positions_by_userid($user->id);
-    foreach ($positions as $position) {
-        $position_names[] = $position->get('name');
-    }
-
-    $positions_output = implode(', ', $position_names);
-
-    $data->attendees[] = (object)[
-        'username' => $user->username,
-        'name' => fullname($user),
-        'position' => $positions_output,
-        'status' => $status,
-    ];
+    $data->attendees[] = (object)[ 'columns' => $column_data ];
 }
+
+// endregion
 
 // Rendering
 $content = $OUTPUT->render_from_template('mod_facetoface/attendance_sheet', $data);
@@ -159,4 +309,5 @@ $content = $OUTPUT->render_from_template('mod_facetoface/attendance_sheet', $dat
 echo $OUTPUT->render_from_template('mod_facetoface/print', [
     'title' => get_string('attendancesheet:heading', 'facetoface'),
     'page' => $content,
+    'landscape' => count($configured_columns) >= 4,
 ]);

--- a/attendance_sheet.php
+++ b/attendance_sheet.php
@@ -79,16 +79,15 @@ $data->custom_fields = [];
 $custom_fields = facetoface_get_session_customfields();
 $custom_field_data = facetoface_get_customfielddata($session->id);
 foreach ($custom_fields as $field) {
-    if (empty($custom_field_data[$field->shortname])) {
-        continue;
-    }
+    $field_data = $custom_field_data[$field->shortname]->data ?? null;
 
-    $field_data = $custom_field_data[$field->shortname]->data;
-    $formatted_data = format_string($field_data);
-
-    if ($field->type === CUSTOMFIELD_TYPE_MULTISELECT) {
-        $values = explode(CUSTOMFIELD_DELIMITER, $formatted_data);
-        $formatted_data = implode(', ', $values);
+    $formatted_data = '';
+    if ($field_data !== null) {
+        $formatted_data = format_string($field_data);
+        if ($field->type === CUSTOMFIELD_TYPE_MULTISELECT) {
+            $values = explode(CUSTOMFIELD_DELIMITER, $formatted_data);
+            $formatted_data = implode(', ', $values);
+        }
     }
 
     $data->custom_fields[] = (object)[

--- a/attendees.php
+++ b/attendees.php
@@ -234,7 +234,23 @@ if ($canviewattendees || $cantakeattendance) {
     if ($takeattendance) {
         $heading = get_string('takeattendance', 'facetoface');
     } else {
-        $heading = get_string('attendees', 'facetoface');
+        $icon = $OUTPUT->pix_icon('t/print', '');
+        $text = get_string('attendees:print', 'facetoface');
+
+        $heading = html_writer::link(
+            new moodle_url(
+                '/mod/facetoface/attendance_sheet.php',
+                [ 'session' => $session->id ]
+            ),
+            "$icon $text",
+            [
+                'class' => 'btn btn-outline-primary float-right m-1',
+                'role' => 'button',
+                'target' => '_blank',
+            ]
+        );
+
+        $heading .= get_string('attendees', 'facetoface');
     }
 
     echo $OUTPUT->heading($heading);

--- a/backup/moodle2/backup_facetoface_stepslib.php
+++ b/backup/moodle2/backup_facetoface_stepslib.php
@@ -44,7 +44,7 @@ class backup_facetoface_activity_structure_step extends backup_activity_structur
             'confirmationsubject', 'confirmationinstrmngr', 'confirmationmessage', 'waitlistedsubject', 'waitlistedmessage',
             'cancellationsubject', 'cancellationinstrmngr', 'cancellationmessage', 'remindersubject', 'reminderinstrmngr',
             'remindermessage', 'reminderperiod', 'requestsubject', 'requestinstrmngr', 'requestmessage',
-            'approvalreqd', 'allowcancellationsdefault', 'attendancesheetshowlogo'));
+            'approvalreqd', 'allowcancellationsdefault', 'attendancesheetshowlogo', 'attendancesheetcolumns'));
 
         $sessions = new backup_nested_element('sessions');
 

--- a/backup/moodle2/backup_facetoface_stepslib.php
+++ b/backup/moodle2/backup_facetoface_stepslib.php
@@ -44,7 +44,7 @@ class backup_facetoface_activity_structure_step extends backup_activity_structur
             'confirmationsubject', 'confirmationinstrmngr', 'confirmationmessage', 'waitlistedsubject', 'waitlistedmessage',
             'cancellationsubject', 'cancellationinstrmngr', 'cancellationmessage', 'remindersubject', 'reminderinstrmngr',
             'remindermessage', 'reminderperiod', 'requestsubject', 'requestinstrmngr', 'requestmessage',
-            'approvalreqd', 'allowcancellationsdefault'));
+            'approvalreqd', 'allowcancellationsdefault', 'attendancesheetshowlogo'));
 
         $sessions = new backup_nested_element('sessions');
 

--- a/classes/enum/attendance_column.php
+++ b/classes/enum/attendance_column.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace mod_facetoface\enum;
+
+class attendance_column extends enum_base {
+
+    const NAME = 0;
+    const USERNAME = 1;
+    const EMAIL = 2;
+    const LEVEL = 3;
+    const POSITION = 4;
+    const STREAM = 5;
+    const PAYPOINT = 6;
+}

--- a/classes/enum/attendance_column.php
+++ b/classes/enum/attendance_column.php
@@ -7,7 +7,7 @@ class attendance_column extends enum_base {
     const NAME = 0;
     const USERNAME = 1;
     const EMAIL = 2;
-    const LEVEL = 3;
+    const UNIT = 3;
     const POSITION = 4;
     const STREAM = 5;
     const PAYPOINT = 6;

--- a/classes/enum/enum_base.php
+++ b/classes/enum/enum_base.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace mod_facetoface\enum;
+
+use ReflectionClass;
+
+abstract class enum_base {
+
+    /**
+     * Get all available constant values indexed by name.
+     *
+     * @return string[] Class constants.
+     */
+    public static function options(): array {
+        $reflection = new ReflectionClass(static::class);
+
+        return $reflection->getConstants();
+    }
+}

--- a/classes/util/enum_util.php
+++ b/classes/util/enum_util.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace mod_facetoface\util;
+
+use coding_exception;
+use mod_facetoface\enum\enum_base;
+
+class enum_util {
+
+    /**
+     * Create a list of menu options from a given enum class.
+     *
+     * @param class-string<enum_base> $class Enum class. Must extend {@link enum_base}.
+     * @return array<mixed, string> List of menu options indexed by enum value.
+     * @throws coding_exception
+     */
+    public static function menu_options(string $class, ?string $lang_identifier = null): array {
+        if ($lang_identifier === null) {
+            $class_parts = explode('\\', $class);
+
+            $lang_identifier = str_replace('_', '', strtolower(end($class_parts)));
+        }
+
+        $menu_options = [];
+        foreach ($class::options() as $value) {
+            $menu_options[$value] = get_string("$lang_identifier:$value", 'mod_facetoface');
+        }
+
+        return $menu_options;
+    }
+}

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="mod/facetoface/db" VERSION="20170530" COMMENT="XMLDB file for Moodle mod/facetoface"
+<XMLDB PATH="mod/facetoface/db" VERSION="2023051700" COMMENT="XMLDB file for Moodle mod/facetoface"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -37,6 +37,7 @@
         <FIELD NAME="usercalentry" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="allowcancellationsdefault" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="attendancesheetshowlogo" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="attendancesheetcolumns" TYPE="char" LENGTH="256" NOTNULL="false" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for facetoface"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -36,6 +36,7 @@
         <FIELD NAME="approvalreqd" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="usercalentry" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
         <FIELD NAME="allowcancellationsdefault" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="attendancesheetshowlogo" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for facetoface"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -747,5 +747,20 @@ function xmldb_facetoface_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2017053000, 'facetoface');
     }
 
+    if ($oldversion < 2023051600) {
+
+        // Define field attendancesheetshowlogo to be added to facetoface.
+        $table = new xmldb_table('facetoface');
+        $field = new xmldb_field('attendancesheetshowlogo', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1', 'allowcancellationsdefault');
+
+        // Conditionally launch add field attendancesheetshowlogo.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Facetoface savepoint reached.
+        upgrade_mod_savepoint(true, 2023051600, 'facetoface');
+    }
+
     return $result;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -762,5 +762,21 @@ function xmldb_facetoface_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2023051600, 'facetoface');
     }
 
+    if ($oldversion < 2023051700) {
+
+        // Define field attendancesheetcolumns to be added to facetoface.
+        $table = new xmldb_table('facetoface');
+        $field = new xmldb_field('attendancesheetcolumns', XMLDB_TYPE_CHAR, '256', null, null, null, null, 'attendancesheetshowlogo');
+
+        // Conditionally launch add field attendancesheetcolumns.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Facetoface savepoint reached.
+        upgrade_mod_savepoint(true, 2023051700, 'facetoface');
+    }
+
+
     return $result;
 }

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -783,3 +783,12 @@ $string['attendancesheet:logsignature'] = 'Entered into LOL - sign';
 $string['attendancesheet:signature'] = 'Signature';
 $string['modform:showlogo'] = 'Show site logo';
 $string['modform:showlogo_help'] = 'Controls whether the site logo is included in the header of the attendance sheet';
+
+// Enum
+$string['attendancecolumn:0'] = 'Name';
+$string['attendancecolumn:1'] = 'Payroll';
+$string['attendancecolumn:2'] = 'Email';
+$string['attendancecolumn:3'] = 'Org Unit';
+$string['attendancecolumn:4'] = 'Position';
+$string['attendancecolumn:5'] = 'Stream';
+$string['attendancecolumn:6'] = 'Paypoint';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -774,3 +774,10 @@ $string['facetoface:addmyattendees'] = 'Add my attendees to a Face-to-face sessi
 $string['facetoface:deletesessions'] = 'Delete Face-to-face sessions';
 $string['facetoface:editsessions'] = 'Add, edit and copy Face-to-face sessions';
 $string['facetoface:removemyattendees'] = 'Remove my attendees from a Face-to-face session';
+
+// Pages
+$string['attendees:print'] = 'Print';
+$string['attendancesheet:heading'] = 'Attendance Sheet';
+$string['attendancesheet:logfacilitator'] = 'Facilitator';
+$string['attendancesheet:logsignature'] = 'Entered into LOL - sign';
+$string['attendancesheet:signature'] = 'Signature';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -781,3 +781,5 @@ $string['attendancesheet:heading'] = 'Attendance Sheet';
 $string['attendancesheet:logfacilitator'] = 'Facilitator';
 $string['attendancesheet:logsignature'] = 'Entered into LOL - sign';
 $string['attendancesheet:signature'] = 'Signature';
+$string['modform:showlogo'] = 'Show site logo';
+$string['modform:showlogo_help'] = 'Controls whether the site logo is included in the header of the attendance sheet';

--- a/lib.php
+++ b/lib.php
@@ -306,9 +306,6 @@ function facetoface_fix_settings($facetoface) {
     if (empty($facetoface->approvalreqd)) {
         $facetoface->approvalreqd = 0;
     }
-    if (empty($facetoface->attendancesheetshowlogo)) {
-        $facetoface->attendancesheetshowlogo = 0;
-    }
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -306,6 +306,9 @@ function facetoface_fix_settings($facetoface) {
     if (empty($facetoface->approvalreqd)) {
         $facetoface->approvalreqd = 0;
     }
+    if (empty($facetoface->attendancesheetshowlogo)) {
+        $facetoface->attendancesheetshowlogo = 0;
+    }
 }
 
 /**

--- a/lib.php
+++ b/lib.php
@@ -306,6 +306,13 @@ function facetoface_fix_settings($facetoface) {
     if (empty($facetoface->approvalreqd)) {
         $facetoface->approvalreqd = 0;
     }
+
+    if (empty($facetoface->attendancesheetcolumns)) {
+        $facetoface->attendancesheetcolumns = null;
+
+    } else {
+        $facetoface->attendancesheetcolumns = implode(',', array_keys($facetoface->attendancesheetcolumns));
+    }
 }
 
 /**

--- a/mod_form.php
+++ b/mod_form.php
@@ -193,7 +193,7 @@ class mod_facetoface_mod_form extends moodleform_mod {
         // Attendance Sheet
         $mform->addElement('header', 'attendancesheetheader', get_string('attendancesheet:heading', 'facetoface'));
 
-        $mform->addElement('advcheckbox', 'attendancesheetshowlogo', get_string('modform:showlogo', 'mod_facetoface'));
+        $mform->addElement('selectyesno', 'attendancesheetshowlogo', get_string('modform:showlogo', 'mod_facetoface'));
         $mform->setDefault('attendancesheetshowlogo', 1);
         $mform->addHelpButton('attendancesheetshowlogo', 'modform:showlogo', 'mod_facetoface');
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -190,6 +190,12 @@ class mod_facetoface_mod_form extends moodleform_mod {
         $mform->disabledIf('cancellationinstrmngr', 'emailmanagercancellation');
         $mform->setDefault('cancellationinstrmngr', get_string('setting:defaultcancellationinstrmngrdefault', 'facetoface'));
 
+        // Attendance Sheet
+        $mform->addElement('header', 'attendancesheetheader', get_string('attendancesheet:heading', 'facetoface'));
+
+        $mform->addElement('checkbox', 'attendancesheetshowlogo', get_string('modform:showlogo', 'mod_facetoface'));
+        $mform->addHelpButton('attendancesheetshowlogo', 'modform:showlogo', 'mod_facetoface');
+
         $features = new stdClass;
         $features->groups = false;
         $features->groupings = false;

--- a/mod_form.php
+++ b/mod_form.php
@@ -193,7 +193,8 @@ class mod_facetoface_mod_form extends moodleform_mod {
         // Attendance Sheet
         $mform->addElement('header', 'attendancesheetheader', get_string('attendancesheet:heading', 'facetoface'));
 
-        $mform->addElement('checkbox', 'attendancesheetshowlogo', get_string('modform:showlogo', 'mod_facetoface'));
+        $mform->addElement('advcheckbox', 'attendancesheetshowlogo', get_string('modform:showlogo', 'mod_facetoface'));
+        $mform->setDefault('attendancesheetshowlogo', 1);
         $mform->addHelpButton('attendancesheetshowlogo', 'modform:showlogo', 'mod_facetoface');
 
         $features = new stdClass;

--- a/mod_form.php
+++ b/mod_form.php
@@ -28,6 +28,8 @@
  * @author     Francois Marier <francois@catalyst.net.nz>
  */
 
+use mod_facetoface\enum\attendance_column;
+
 defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/course/moodleform_mod.php');
@@ -197,6 +199,12 @@ class mod_facetoface_mod_form extends moodleform_mod {
         $mform->setDefault('attendancesheetshowlogo', 1);
         $mform->addHelpButton('attendancesheetshowlogo', 'modform:showlogo', 'mod_facetoface');
 
+        $column_checkboxes = [];
+        foreach (self::attendance_sheet_column_options() as $key => $label) {
+            $column_checkboxes[] = $mform->createElement('checkbox', $key, $label);
+        }
+        $mform->addGroup($column_checkboxes, 'attendancesheetcolumns', 'Columns', html_writer::empty_tag('br'));
+
         $features = new stdClass;
         $features->groups = false;
         $features->groupings = false;
@@ -229,6 +237,14 @@ class mod_facetoface_mod_form extends moodleform_mod {
         } else {
             $defaultvalues['emailmanagercancellation'] = 1;
         }
+
+        if (empty($defaultvalues['attendancesheetcolumns'])) {
+            $defaultvalues['attendancesheetcolumns'] = [];
+
+        } else {
+            $keys = explode(',', $defaultvalues['attendancesheetcolumns']);
+            $defaultvalues['attendancesheetcolumns'] = array_fill_keys($keys, 1);
+        }
     }
 
     /**
@@ -258,5 +274,20 @@ class mod_facetoface_mod_form extends moodleform_mod {
      */
     public function completion_rule_enabled($data) {
         return !empty($data['completionpass']);
+    }
+
+    /**
+     * Get the list of attendance sheet column options.
+     *
+     * @return string[] List of options.
+     * @throws coding_exception
+     */
+    private static function attendance_sheet_column_options(): array {
+        $options = [];
+        foreach (attendance_column::options() as $key) {
+            $options[$key] = get_string("attendancecolumn:$key", 'mod_facetoface');
+        }
+
+        return $options;
     }
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -29,6 +29,7 @@
  */
 
 use mod_facetoface\enum\attendance_column;
+use mod_facetoface\util\enum_util;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -200,7 +201,8 @@ class mod_facetoface_mod_form extends moodleform_mod {
         $mform->addHelpButton('attendancesheetshowlogo', 'modform:showlogo', 'mod_facetoface');
 
         $column_checkboxes = [];
-        foreach (self::attendance_sheet_column_options() as $key => $label) {
+        $column_options = enum_util::menu_options(attendance_column::class);
+        foreach ($column_options as $key => $label) {
             $column_checkboxes[] = $mform->createElement('checkbox', $key, $label);
         }
         $mform->addGroup($column_checkboxes, 'attendancesheetcolumns', 'Columns', html_writer::empty_tag('br'));
@@ -238,7 +240,10 @@ class mod_facetoface_mod_form extends moodleform_mod {
             $defaultvalues['emailmanagercancellation'] = 1;
         }
 
-        if (empty($defaultvalues['attendancesheetcolumns'])) {
+        if (
+            !isset($defaultvalues['attendancesheetcolumns']) ||
+            $defaultvalues['attendancesheetcolumns'] === ''
+        ) {
             $defaultvalues['attendancesheetcolumns'] = [];
 
         } else {
@@ -274,20 +279,5 @@ class mod_facetoface_mod_form extends moodleform_mod {
      */
     public function completion_rule_enabled($data) {
         return !empty($data['completionpass']);
-    }
-
-    /**
-     * Get the list of attendance sheet column options.
-     *
-     * @return string[] List of options.
-     * @throws coding_exception
-     */
-    private static function attendance_sheet_column_options(): array {
-        $options = [];
-        foreach (attendance_column::options() as $key) {
-            $options[$key] = get_string("attendancecolumn:$key", 'mod_facetoface');
-        }
-
-        return $options;
     }
 }

--- a/templates/attendance_sheet.mustache
+++ b/templates/attendance_sheet.mustache
@@ -42,6 +42,10 @@
         width: 15%;
     }
 
+    .signoff-table {
+        break-inside: avoid-page;
+    }
+
     .signoff-table table {
         table-layout: fixed;
         width: 60%;

--- a/templates/attendance_sheet.mustache
+++ b/templates/attendance_sheet.mustache
@@ -1,0 +1,140 @@
+<style>
+    .sheet-section {
+        margin-bottom: 2rem;
+    }
+
+    table.table {
+        margin-bottom: 0;
+    }
+
+    .table.table-thick th,
+    .table.table-thick td {
+        border: 2px solid black !important;
+    }
+
+    .table.table-writable thead tr {
+        height: 35px;
+    }
+
+    .table.table-writable tbody tr {
+        height: 50px;
+    }
+
+    .table.table-writable th,
+    .table.table-writable td {
+        vertical-align: top;
+    }
+
+    .details-table table {
+        align-self: flex-start;
+    }
+
+    .details-table table td,
+    .details-table table th {
+        border-top: 1px solid #9f9f9f;
+    }
+
+    .attendees-table table {
+        table-layout: fixed;
+    }
+
+    .signoff-table table {
+        table-layout: fixed;
+        width: 60%;
+    }
+</style>
+
+<div class="sheet-section d-flex">
+    <h1 class="flex-grow-1 align-self-center">
+        {{#str}} attendancesheet:heading, mod_facetoface {{/str}}
+    </h1>
+
+    {{#logo_url}}
+        <img src="{{logo_url}}" alt="Site Logo" />
+    {{/logo_url}}
+</div>
+
+<div class="details-table sheet-section d-flex">
+    <table class="table">
+        <tbody>
+            <tr>
+                <th>{{course_name}}</th>
+            </tr>
+            <tr>
+                <th>{{instance_name}}</th>
+            </tr>
+
+            {{#session_date}}
+                <tr>
+                    <th>{{{session_date}}}</th>
+                </tr>
+            {{/session_date}}
+        </tbody>
+    </table>
+
+    <table class="table">
+        <tbody>
+            {{#custom_fields}}
+                <tr>
+                    <th>{{name}}</th>
+                    <td>{{value}}</td>
+                </tr>
+            {{/custom_fields}}
+
+            {{#trainers}}
+                <tr>
+                    <th>{{role}}</th>
+                    <td>{{names}}</td>
+                </tr>
+            {{/trainers}}
+        </tbody>
+    </table>
+</div>
+
+<div class="attendees-table sheet-section">
+    <h2>{{#str}} attendees, mod_facetoface {{/str}}</h2>
+
+    <table class="table table-bordered table-thick table-writable">
+        <thead>
+            <tr>
+                <th>{{#str}} username {{/str}}</th>
+                <th>{{#str}} name {{/str}}</th>
+                <th>{{#str}} position, tool_organisation {{/str}}</th>
+                <th>{{#str}} attendancesheet:signature, mod_facetoface {{/str}}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#attendees}}
+                <tr>
+                    <td>{{username}}</td>
+                    <td>{{name}}</td>
+                    <td>{{position}}</td>
+                    <td>{{status}}</td>
+                </tr>
+            {{/attendees}}
+
+            <tr><td></td><td></td><td></td><td></td></tr>
+            <tr><td></td><td></td><td></td><td></td></tr>
+            <tr><td></td><td></td><td></td><td></td></tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="signoff-table sheet-section d-flex justify-content-end">
+    <table class="table table-bordered table-thick table-writable">
+        <tbody>
+            <tr>
+                <th>{{#str}} attendancesheet:logsignature, mod_facetoface {{/str}}</th>
+                <td></td>
+            </tr>
+            <tr>
+                <th>{{#str}} attendancesheet:logfacilitator, mod_facetoface {{/str}}</th>
+                <td></td>
+            </tr>
+            <tr>
+                <th>{{#str}} date {{/str}}</th>
+                <td></td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/templates/attendance_sheet.mustache
+++ b/templates/attendance_sheet.mustache
@@ -35,7 +35,11 @@
     }
 
     .attendees-table table {
-        table-layout: fixed;
+        word-wrap: break-word;
+    }
+
+    .attendees-table table .heading-signature {
+        width: 15%;
     }
 
     .signoff-table table {
@@ -97,25 +101,29 @@
     <table class="table table-bordered table-thick table-writable">
         <thead>
             <tr>
-                <th>{{#str}} username {{/str}}</th>
-                <th>{{#str}} name {{/str}}</th>
-                <th>{{#str}} position, tool_organisation {{/str}}</th>
-                <th>{{#str}} attendancesheet:signature, mod_facetoface {{/str}}</th>
+                {{#headings}}
+                    <th class="heading-{{key}}">
+                        {{label}}
+                    </th>
+                {{/headings}}
+
+                <th class="heading-signature">
+                    {{#str}} attendancesheet:signature, mod_facetoface {{/str}}
+                </th>
             </tr>
         </thead>
         <tbody>
             {{#attendees}}
                 <tr>
-                    <td>{{username}}</td>
-                    <td>{{name}}</td>
-                    <td>{{position}}</td>
-                    <td>{{status}}</td>
+                    {{#columns}}
+                        <td>{{.}}</td>
+                    {{/columns}}
                 </tr>
             {{/attendees}}
 
-            <tr><td></td><td></td><td></td><td></td></tr>
-            <tr><td></td><td></td><td></td><td></td></tr>
-            <tr><td></td><td></td><td></td><td></td></tr>
+            <tr>{{#headings}}<td></td>{{/headings}}<td></td></tr>
+            <tr>{{#headings}}<td></td>{{/headings}}<td></td></tr>
+            <tr>{{#headings}}<td></td>{{/headings}}<td></td></tr>
         </tbody>
     </table>
 </div>

--- a/templates/print.mustache
+++ b/templates/print.mustache
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>
+        {{#title}}{{title}}{{/title}}
+        {{^title}}Print{{/title}}
+    </title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+            margin: auto;
+
+        {{^landscape}}
+            width: 210mm;
+            height: 297mm;
+        {{/landscape}}
+        }
+        * {
+            -webkit-print-color-adjust: exact !important;   /* Chrome, Safari */
+            color-adjust: exact !important;                 /*Firefox*/
+        }
+        #ciap-gauge-chart table {
+            margin: 0 auto !important;
+        }
+        .table caption {
+            caption-side: top;
+            padding-top: .572rem;
+            padding-bottom: .572rem;
+            font-weight: bold;
+        }
+        .table th {
+            padding: 0.25rem;
+        }
+        .table td {
+            padding: 0.25rem;
+            vertical-align: middle;
+        }
+        .text-primary {color: #069 !important;}
+        @page {
+            {{#landscape}}size: landscape;{{/landscape}}
+            {{^landscape}}size: A4;{{/landscape}}
+            margin: auto;
+        }
+        @media print {
+            html, body {
+                -webkit-print-color-adjust: exact !important;
+                color-adjust: exact !important;
+
+            {{^landscape}}
+                width: 21cm;
+                height: 297mm;
+            {{/landscape}}
+            }
+
+            .pagebreak {
+                clear: both;
+                page-break-before: always;
+                break-after: all;
+            } /* page-break-after works, as well */
+
+            .chart-div {
+                break-inside: avoid;
+            }
+
+        {{#apply_table_colours}}
+            .table .table-primary,
+            .table .table-primary > th,
+            .table .table-primary > td {
+                background-color: #b8daff !important;
+            }
+
+            .table .table-primary th,
+            .table .table-primary td,
+            .table .table-primary thead th,
+            .table .table-primary tbody + tbody {
+                border-color: #7abaff !important;
+            }
+
+            .table .table-secondary,
+            .table .table-secondary > th,
+            .table .table-secondary > td {
+                background-color: #d6d8db !important;
+            }
+
+            .table .table-secondary th,
+            .table .table-secondary td,
+            .table .table-secondary thead th,
+            .table .table-secondary tbody + tbody {
+                border-color: #b3b7bb !important;
+            }
+
+            .table .table-success,
+            .table .table-success > th,
+            .table .table-success > td {
+                background-color: #c3e6cb !important;
+            }
+
+            .table .table-success th,
+            .table .table-success td,
+            .table .table-success thead th,
+            .table .table-success tbody + tbody {
+                border-color: #8fd19e !important;
+            }
+
+            .table .table-info,
+            .table .table-info > th,
+            .table .table-info > td {
+                background-color: #bee5eb !important;
+            }
+
+            .table .table-info th,
+            .table .table-info td,
+            .table .table-info thead th,
+            .table .table-info tbody + tbody {
+                border-color: #86cfda !important;
+            }
+
+            .table .table-warning,
+            .table .table-warning > th,
+            .table .table-warning > td {
+                background-color: #ffeeba !important;
+            }
+
+            .table .table-warning th,
+            .table .table-warning td,
+            .table .table-warning thead th,
+            .table .table-warning tbody + tbody {
+                border-color: #ffdf7e !important;
+            }
+
+            .table .table-danger,
+            .table .table-danger > th,
+            .table .table-danger > td {
+                background-color: #f5c6cb !important;
+            }
+
+            .table .table-danger th,
+            .table .table-danger td,
+            .table .table-danger thead th,
+            .table .table-danger tbody + tbody {
+                border-color: #ed969e !important;
+            }
+
+            .table .table-light,
+            .table .table-light > th,
+            .table .table-light > td {
+                background-color: #fdfdfe !important;
+            }
+
+            .table .table-light th,
+            .table .table-light td,
+            .table .table-light thead th,
+            .table .table-light tbody + tbody {
+                border-color: #fbfcfc !important;
+            }
+        {{/apply_table_colours}}
+        }
+    </style>
+</head>
+<body>
+
+{{#use_container}}
+    <div class="container">
+{{/use_container}}
+    {{#heading}}
+        <h1 style="text-align: center">{{heading}}</h1>
+    {{/heading}}
+
+    {{{page}}}
+{{#use_container}}
+    </div>
+{{/use_container}}
+
+<script type="text/javascript">
+    {{^manual_trigger}}
+        window.print();
+    {{/manual_trigger}}
+
+    window.onafterprint = function(){
+        window.close();
+    }
+</script>
+</body>
+</html>

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023051600;
+$plugin->version   = 2023051700;
 $plugin->requires  = 2017111300;  // Requires 3.4.
 $plugin->release   = '3.9.1';
 $plugin->component = 'mod_facetoface';

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023051700;
+$plugin->version   = 2023051701;
 $plugin->requires  = 2017111300;  // Requires 3.4.
 $plugin->release   = '3.9.1';
 $plugin->component = 'mod_facetoface';

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2020080401;
+$plugin->version   = 2023051600;
 $plugin->requires  = 2017111300;  // Requires 3.4.
 $plugin->release   = '3.9.1';
 $plugin->component = 'mod_facetoface';


### PR DESCRIPTION
Adds a printable attendance sheet available via the print button on the attendees list and configurable in the module settings.

Features:
1. Site logo included in the sheet's header.
   1. Logo as configured in `Site Administration > Appearance > Logos`.
   2. Output can be disabled via module settings `Module Settings > Attendance Sheet > Show site logo`.
2. Details table to display important course, module, and session information.
   1. Intentionally includes all configured custom fields even when no value is set.
   2. Displays facilitator when set.
3. Attendees table with fully configurable column output.
   1. Configurable via `Module Settings > Attendance Sheet > Columns`.
   3. Defaults to: name, payroll, and position when not configured.
   4. Supports: name, payroll, email, unit, position, stream, and paypoint columns.
   5. Fixed signature column is always output last and populated with the attendee's status when anything other than booked.
   6. Automatically shifts the page to landscape if 4 or more configurable columns (not including signature) are set.
   7. Always displays three blank rows after attendees for manual additions on the printed document.
4. Sheet signoff table to note that the data has been entered into LOL.