### PR TITLE
Session Date Format Option

### DIFF
--- a/attendance_sheet.php
+++ b/attendance_sheet.php
@@ -72,13 +72,7 @@ if ($session->datetimeknown) {
     $session_dates = [];
     foreach ($session->sessiondates as $date) {
         $date_data = facetoface_format_session_times($date->timestart, $date->timefinish, null);
-
-        $session_lang_key = !empty($sessionobj->timezone) ? 'sessionstartdateandtime' : 'sessionstartdateandtimewithouttimezone';
-        if ($date_data->startdate !== $date_data->enddate) {
-            $session_lang_key = !empty($sessionobj->timezone) ? 'sessionstartfinishdateandtime' : 'sessionstartfinishdateandtimewithouttimezone';
-        }
-
-        $session_dates[] = get_string($session_lang_key, 'facetoface', $date_data);
+        $session_dates[] = $date_data->datetime;
     }
 
     $data->session_date = implode(html_writer::empty_tag('br'), $session_dates);

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -775,6 +775,10 @@ $string['facetoface:deletesessions'] = 'Delete Face-to-face sessions';
 $string['facetoface:editsessions'] = 'Add, edit and copy Face-to-face sessions';
 $string['facetoface:removemyattendees'] = 'Remove my attendees from a Face-to-face session';
 
+// Core
+$string['session:strftimedate'] = '';
+$string['session:strftimetime'] = '';
+
 // Pages
 $string['attendees:print'] = 'Print';
 $string['attendancesheet:heading'] = 'Attendance Sheet';

--- a/lib.php
+++ b/lib.php
@@ -2533,10 +2533,20 @@ function facetoface_format_session_times($start, $end, $tz) {
         $targettz = core_date::get_user_timezone($tz);
     }
 
-    $formattedsession->startdate = userdate($start, get_string('strftimedate', 'langconfig'), $targettz);
-    $formattedsession->starttime = userdate($start, get_string('strftimetime', 'langconfig'), $targettz);
-    $formattedsession->enddate = userdate($end, get_string('strftimedate', 'langconfig'), $targettz);
-    $formattedsession->endtime = userdate($end, get_string('strftimetime', 'langconfig'), $targettz);
+    $date_format = get_string('session:strftimedate', 'facetoface');
+    if (empty($date_format)) {
+        $date_format = get_string('strftimedate', 'langconfig');
+    }
+
+    $time_format = get_string('session:strftimetime', 'facetoface');
+    if (empty($time_format)) {
+        $time_format = get_string('strftimetime', 'langconfig');
+    }
+
+    $formattedsession->startdate = userdate($start, $date_format, $targettz);
+    $formattedsession->starttime = userdate($start, $time_format, $targettz);
+    $formattedsession->enddate = userdate($end, $date_format, $targettz);
+    $formattedsession->endtime = userdate($end, $time_format, $targettz);
     if (empty($displaytimezones)) {
         $formattedsession->timezone = '';
     } else {

--- a/renderer.php
+++ b/renderer.php
@@ -34,7 +34,7 @@ class mod_facetoface_renderer extends plugin_renderer_base {
 
     /**
      * Builds session list table given an array of sessions
-     * 
+     *
      * GCHLOL - MF - Added $deletesessions to parameters
      */
     public function print_session_list_table($customfields, $sessions, $viewattendees, $editsessions, $deletesessions = false) {
@@ -94,15 +94,17 @@ class mod_facetoface_renderer extends plugin_renderer_base {
             $allsessiontimes = '';
             if ($session->datetimeknown) {
                 foreach ($session->sessiondates as $date) {
+                    $sessionobj = facetoface_format_session_times($date->timestart, $date->timefinish, null);
+
                     if (!empty($allsessiondates)) {
                         $allsessiondates .= html_writer::empty_tag('br');
                     }
-                    $allsessiondates .= userdate($date->timestart, get_string('strftimedate'));
+                    $allsessiondates .= $sessionobj->startdate;
+
                     if (!empty($allsessiontimes)) {
                         $allsessiontimes .= html_writer::empty_tag('br');
                     }
-                    $allsessiontimes .= userdate($date->timestart, get_string('strftimetime')).
-                        ' - '.userdate($date->timefinish, get_string('strftimetime'));
+                    $allsessiontimes .= "$sessionobj->starttime - $sessionobj->endtime";
                 }
             } else {
                 $allsessiondates = get_string('wait-listed', 'facetoface');


### PR DESCRIPTION
Add optional session date and time format language overrides.
These follow the same formatting as the core `strftimedate` and `strftimetime` strings. When empty as at default, the core language string will be used.
Example: Setting `session:strftimedate` to '%A %d %B %Y' will add the day of week to the start of the session date.