### PR TITLE
GS-541 Attendance Sheet Printout Has No Margins

### DIFF
--- a/templates/print.mustache
+++ b/templates/print.mustache
@@ -41,7 +41,7 @@
         .text-primary {color: #069 !important;}
         @page {
             size: A4{{#landscape}} landscape{{/landscape}};
-            margin: auto;
+            margin: 10mm;
         }
         @media print {
             html, body {

--- a/templates/print.mustache
+++ b/templates/print.mustache
@@ -40,8 +40,7 @@
         }
         .text-primary {color: #069 !important;}
         @page {
-            {{#landscape}}size: landscape;{{/landscape}}
-            {{^landscape}}size: A4;{{/landscape}}
+            size: A4{{#landscape}} landscape{{/landscape}};
             margin: auto;
         }
         @media print {


### PR DESCRIPTION
1. Add 10mm margin to all pages when printing to prevent content being cut off.
2. Change page definition to always define 'A4' but conditionally add 'landscape'.