### PR TITLE
GS-610 Restore Course Page Cancel Booking Link

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2947,6 +2947,12 @@ function facetoface_cm_info_view(cm_info $coursemodule) {
                         'class' => 'f2fsessionlinks f2fsessioninfolink',
                         'title' => $strmoreinfo,
                     ]);
+
+                    if ($session->allowcancellations) {
+                        $strcancel  = get_string('cancelbooking', 'facetoface');
+                        $cancelurl  = new moodle_url('/mod/facetoface/cancelsignup.php', [ 's' => $session->id ]);
+                        $cancellink = ' ' . html_writer::link($cancelurl, $strcancel, [ 'class' => 'f2fsessionlinks f2fcancel', 'title' => $strcancel ]);
+                    }
                 }
 
                 // Don't include the link to view attendees if user is lacking capability.


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Restore the course page inline cancel booking link that appears to have been accidentally removed in 6303cb416f1f573bd1b3372cbb5bebb935fa91e0.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
