### PR TITLE
GS-597 Remove Legacy Completion Setting

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2790,30 +2790,6 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
         }
     }
 
-    // GCHLOL
-    if ($record->completionpass) {
-        $cm = get_coursemodule_from_instance('facetoface', $record->id);
-        $sql = 'SELECT timefinish
-                  FROM {facetoface_sessions_dates}
-                 WHERE sessionid = ?
-              ORDER BY timefinish DESC
-                 LIMIT 1';
-        $sessiondate = $DB->get_record_sql($sql, array($record->sessionid));
-
-        $course = get_course($record->course);
-
-        $completion = new completion_info($course);
-        if ($completion->is_enabled($cm)) {
-            $completion->update_state($cm, COMPLETION_COMPLETE);
-        }
-
-        $status = $DB->get_record('facetoface_signups_status', array('signupid' => $submissionid, 'superceded' => 0));
-
-        if ($status->statuscode == 100) {
-            facetoface_mark_complete($record, $cm->id, $record->userid, $sessiondate->timefinish);
-        }
-    }
-
     return $result;
 }
 
@@ -4924,40 +4900,4 @@ function facetoface_mark_complete($facetoface, $cmid, $userid, $timecompleted) {
     aggregate_completions($completion->id);
 
     return $result;
-}
-
-/**
- * Obtains the automatic completion state for this quiz on any conditions
- * in quiz settings, such as if all attempts are used or a certain grade is achieved.
- *
- * GCHLOL
- *
- * @param object $course Course
- * @param object $cm     Course-module
- * @param int    $userid User ID
- * @param bool   $type   Type of comparison (or/and; can be used as return value if no conditions)
- * @return bool True if completed, false if not. (If no conditions, then return
- *   value depends on comparison type)
- */
-function facetoface_get_completion_state($course, $cm, $userid, $type) {
-    global $CFG, $DB;
-
-    $facetoface = $DB->get_record('facetoface', array('id' => $cm->instance), '*', MUST_EXIST);
-    if (!$facetoface->completionpass) {
-        return $type;
-    }
-
-    // Check for passing grade.
-    if ($facetoface->completionpass) {
-        require_once($CFG->libdir . '/gradelib.php');
-        $item = grade_item::fetch(array('courseid' => $course->id, 'itemtype' => 'mod',
-            'itemmodule' => 'facetoface', 'iteminstance' => $cm->instance, 'outcomeid' => null));
-        if ($item) {
-            $grades = grade_grade::fetch_users_grades($item, array($userid), false);
-            if (!empty($grades[$userid])) {
-                return $grades[$userid]->is_passed($item);
-            }
-        }
-    }
-    return false;
 }

--- a/mod_form.php
+++ b/mod_form.php
@@ -375,17 +375,7 @@ class mod_facetoface_mod_form extends moodleform_mod {
         $mform->addElement('select', 'completionattendance', get_string('completiondetail:attendance', 'facetoface'), $options);
         $mform->setDefault('completionattendance', MDL_F2F_STATUS_FULLY_ATTENDED);
 
-        $group = array();
-        $group[] = $mform->createElement('advcheckbox', 'completionpass', null, get_string('completionpass', 'quiz'),
-            array('group' => 'cpass'));
-        $mform->disabledIf('completionpass', 'notchecked');
-        $mform->addGroup($group, 'completionpassgroup', get_string('completionpass', 'quiz'), ' &nbsp; ', false);
-        $mform->addHelpButton('completionpassgroup', 'completionpass', 'quiz');
-
-        return [
-            'completionattendance',
-            'completionpassgroup'
-        ];
+        return ['completionattendance'];
     }
 
     /**
@@ -395,6 +385,6 @@ class mod_facetoface_mod_form extends moodleform_mod {
      * @return bool true if custom completion enabled
      */
     public function completion_rule_enabled($data): bool {
-        return !empty($data['completionattendance']) || !empty($data['completionpass']);
+        return !empty($data['completionattendance']);
     }
 }


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Remove legacy 'completionpass' option as it is replaced by 'completionattendance'.
Has additional manual DB migration SQL attached to issue as deployment note to drop the 'completionpass' column and set 'completionattendance' to 100 (require full attendance).

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
