### PR TITLE
GS-764 Waitlist Order Fix

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1224,8 +1224,6 @@ function facetoface_get_attendees($sessionid) {
         AND ss.superceded != 1
         AND ss.statuscode >= ?
         ORDER BY
-            u.firstname,
-            u.lastname,
             sign.timecreated ASC,
             ss.timecreated ASC
     ", [$sessionid, MDL_F2F_STATUS_BOOKED, MDL_F2F_STATUS_WAITLISTED, $sessionid, MDL_F2F_STATUS_APPROVED]);
@@ -4679,7 +4677,7 @@ class facetoface_mycandidate_selector extends user_selector_base {
         $sql = "
               FROM  {user} u
                 $joinsstring
-              WHERE $where and 
+              WHERE $where and
                     u.suspended = 0 AND
                     u.id NOT IN
                     (

--- a/lib.php
+++ b/lib.php
@@ -4679,7 +4679,7 @@ class facetoface_mycandidate_selector extends user_selector_base {
         $sql = "
               FROM  {user} u
                 $joinsstring
-              WHERE $where and 
+              WHERE $where and
                     u.suspended = 0 AND
                     u.id NOT IN
                     (
@@ -4905,51 +4905,66 @@ function facetoface_mark_complete($facetoface, $cmid, $userid, $timecompleted) {
 /**
  * Get list of users attending a given session ordered by signup time.
  *
- * @access public
- * @param integer Session ID
- * @return array List of user records with signup details
+ * @param int $sessionid Session ID.
+ * @return stdClass[] List of user records with signup details.
  */
-function facetoface_get_attendees_by_signup($sessionid) {
+function facetoface_get_attendees_by_signup(int $sessionid): array {
     global $DB;
 
     $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
-    return $DB->get_records_sql("
-        SELECT  u.id, {$usernamefields},
-                u.email,
-                su.id AS submissionid,
-                s.discountcost,
-                su.discountcode,
-                su.notificationtype,
-                f.id AS facetofaceid,
-                f.course,
-                ss.grade,
-                ss.statuscode,
-                sign.timecreated
-        FROM    {facetoface} f
-                JOIN {facetoface_sessions} s ON
-                    s.facetoface = f.id
-                JOIN {facetoface_signups} su ON
-                    s.id = su.sessionid
-                JOIN {facetoface_signups_status} ss ON
-                    su.id = ss.signupid
+
+    $sql = "
+        SELECT  user.id,
+                " . $usernamefields . ",
+                user.email,
+                signups.id AS submissionid,
+                sessions.discountcost,
+                signups.discountcode,
+                signups.notificationtype,
+                facetoface.id AS facetofaceid,
+                facetoface.course,
+                status.grade,
+                status.statuscode,
+                latest_status.timecreated
+
+        FROM    {facetoface} facetoface
+                JOIN {facetoface_sessions} sessions ON
+                    sessions.facetoface = facetoface.id
+                JOIN {facetoface_signups} signups ON
+                    sessions.id = signups.sessionid
+                JOIN {facetoface_signups_status} status ON
+                    signups.id = status.signupid
                 LEFT JOIN (
                     SELECT  ss.signupid,
                             MAX(ss.timecreated) AS timecreated
                     FROM    {facetoface_signups_status} ss
                             JOIN {facetoface_signups} s ON
-                                s.id = ss.signupid AND
-                                s.sessionid = ?
-                    WHERE ss.statuscode IN (?,?)
-                    GROUP BY ss.signupid
-                ) sign ON
-                    su.id = sign.signupid
-                JOIN {user} u ON
-                    u.id = su.userid
-        WHERE   s.id = ? AND
-                ss.superceded <> 1 AND
-                ss.statuscode >= ?
+                                ss.signupid = s.id AND
+                                ss.sessionid = :sessionid_sub
+                    WHERE   ss.statuscode IN (:status_booked, :status_waitlisted)
+                    GROUP BY
+                            ss.signupid
+                ) latest_status ON
+                    signups.id = latest_status.signupid
+                JOIN {user} user ON
+                    user.id = signups.userid
+
+        WHERE   sessions.id = :sessionid_main
+                AND status.superceded <> 1
+                AND status.statuscode >= :status_approved
+
         ORDER BY
-                sign.timecreated ASC,
-                ss.timecreated ASC
-    ", [$sessionid, MDL_F2F_STATUS_BOOKED, MDL_F2F_STATUS_WAITLISTED, $sessionid, MDL_F2F_STATUS_APPROVED]);
+                latest_status.timecreated ASC,
+                status.timecreated ASC
+    ";
+
+    $params = [
+        'sessionid_sub' => $sessionid,
+        'status_booked' => MDL_F2F_STATUS_BOOKED,
+        'status_waitlisted' => MDL_F2F_STATUS_WAITLISTED,
+        'sessionid_main' => $sessionid,
+        'status_approved' => MDL_F2F_STATUS_APPROVED,
+    ];
+
+    return $DB->get_records_sql($sql, $params);
 }

--- a/lib.php
+++ b/lib.php
@@ -593,7 +593,7 @@ function facetoface_update_attendees($session) {
     $course = $DB->get_record('course', ['id' => $facetoface->course]);
 
     // Update user status'.
-    $users = facetoface_get_attendees($session->id);
+    $users = facetoface_get_attendees_by_signup($session->id);
 
     if ($users) {
         // No/deleted session dates.
@@ -4898,4 +4898,56 @@ function facetoface_mark_complete($facetoface, $cmid, $userid, $timecompleted) {
     aggregate_completions($completion->id);
 
     return $result;
+}
+
+/**
+ * Get list of users attending a given session ordered by signup time.
+ *
+ * @access public
+ * @param integer Session ID
+ * @return array List of user records with signup details
+ */
+function facetoface_get_attendees_by_signup($sessionid) {
+    global $DB;
+
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
+    return $DB->get_records_sql("
+        SELECT  u.id, {$usernamefields},
+                u.email,
+                su.id AS submissionid,
+                s.discountcost,
+                su.discountcode,
+                su.notificationtype,
+                f.id AS facetofaceid,
+                f.course,
+                ss.grade,
+                ss.statuscode,
+                sign.timecreated
+        FROM    {facetoface} f
+                JOIN {facetoface_sessions} s ON
+                    s.facetoface = f.id
+                JOIN {facetoface_signups} su ON
+                    s.id = su.sessionid
+                JOIN {facetoface_signups_status} ss ON
+                    su.id = ss.signupid
+                LEFT JOIN (
+                    SELECT  ss.signupid,
+                            MAX(ss.timecreated) AS timecreated
+                    FROM    {facetoface_signups_status} ss
+                            JOIN {facetoface_signups} s ON
+                                s.id = ss.signupid AND
+                                s.sessionid = ?
+                    WHERE ss.statuscode IN (?,?)
+                    GROUP BY ss.signupid
+                ) sign ON
+                    su.id = sign.signupid
+                JOIN {user} u ON
+                    u.id = su.userid
+        WHERE   s.id = ? AND
+                ss.superceded <> 1 AND
+                ss.statuscode >= ?
+        ORDER BY
+                sign.timecreated ASC,
+                ss.timecreated ASC
+    ", [$sessionid, MDL_F2F_STATUS_BOOKED, MDL_F2F_STATUS_WAITLISTED, $sessionid, MDL_F2F_STATUS_APPROVED]);
 }

--- a/lib.php
+++ b/lib.php
@@ -4911,7 +4911,7 @@ function facetoface_mark_complete($facetoface, $cmid, $userid, $timecompleted) {
 function facetoface_get_attendees_by_signup(int $sessionid): array {
     global $DB;
 
-    $usernamefields = facetoface_get_all_user_name_fields(true, 'u');
+    $usernamefields = facetoface_get_all_user_name_fields(true, 'user');
 
     $sql = "
         SELECT  user.id,
@@ -4934,19 +4934,20 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
                     sessions.id = signups.sessionid
                 JOIN {facetoface_signups_status} status ON
                     signups.id = status.signupid
+
                 LEFT JOIN (
-                    SELECT  ss.signupid,
-                            MAX(ss.timecreated) AS timecreated
+                    SELECT  signup_status.signupid,
+                            MAX(signup_status.timecreated) AS timecreated
 
-                    FROM    {facetoface_signups_status} ss
-                            JOIN {facetoface_signups} s ON
-                                ss.signupid = s.id AND
-                                s.sessionid = :sessionid_sub
+                    FROM    {facetoface_signups_status} signup_status
+                            JOIN {facetoface_signups} signup ON
+                                signup_status.signupid = signup.id AND
+                                signup.sessionid = :sessionid_sub
 
-                    WHERE   ss.statuscode IN (:status_booked, :status_waitlisted)
-                    
+                    WHERE   signup_status.statuscode IN (:status_booked, :status_waitlisted)
+
                     GROUP BY
-                            ss.signupid
+                            signup_status.signupid
                 ) latest_status ON
                     signups.id = latest_status.signupid
                 JOIN {user} user ON

--- a/lib.php
+++ b/lib.php
@@ -4937,11 +4937,14 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
                 LEFT JOIN (
                     SELECT  ss.signupid,
                             MAX(ss.timecreated) AS timecreated
+
                     FROM    {facetoface_signups_status} ss
                             JOIN {facetoface_signups} s ON
                                 ss.signupid = s.id AND
-                                ss.sessionid = :sessionid_sub
+                                s.sessionid = :sessionid_sub
+
                     WHERE   ss.statuscode IN (:status_booked, :status_waitlisted)
+                    
                     GROUP BY
                             ss.signupid
                 ) latest_status ON

--- a/lib.php
+++ b/lib.php
@@ -4915,7 +4915,7 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
 
     $sql = "
         SELECT  user.id,
-                " . $usernamefields . ",
+                $usernamefields,
                 user.email,
                 signups.id AS submissionid,
                 sessions.discountcost,
@@ -4923,17 +4923,17 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
                 signups.notificationtype,
                 facetoface.id AS facetofaceid,
                 facetoface.course,
-                status.grade,
-                status.statuscode,
+                signups_status.grade,
+                signups_status.statuscode,
                 latest_status.timecreated
 
         FROM    {facetoface} facetoface
                 JOIN {facetoface_sessions} sessions ON
                     sessions.facetoface = facetoface.id
                 JOIN {facetoface_signups} signups ON
-                    sessions.id = signups.sessionid
-                JOIN {facetoface_signups_status} status ON
-                    signups.id = status.signupid
+                    signups.sessionid = sessions.id
+                JOIN {facetoface_signups_status} signups_status ON
+                    signups_status.signupid = signups.id
 
                 LEFT JOIN (
                     SELECT  signup_status.signupid,
@@ -4941,7 +4941,7 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
 
                     FROM    {facetoface_signups_status} signup_status
                             JOIN {facetoface_signups} signup ON
-                                signup_status.signupid = signup.id AND
+                                signup.id = signup_status.signupid AND
                                 signup.sessionid = :sessionid_sub
 
                     WHERE   signup_status.statuscode IN (:status_booked, :status_waitlisted)
@@ -4949,17 +4949,18 @@ function facetoface_get_attendees_by_signup(int $sessionid): array {
                     GROUP BY
                             signup_status.signupid
                 ) latest_status ON
-                    signups.id = latest_status.signupid
-                JOIN {user} user ON
+                    latest_status.signupid = signups.id
+
+                    JOIN {user} user ON
                     user.id = signups.userid
 
-        WHERE   sessions.id = :sessionid_main
-                AND status.superceded <> 1
-                AND status.statuscode >= :status_approved
+        WHERE   sessions.id = :sessionid_main AND
+                signups_status.superceded <> 1 AND
+                signups_status.statuscode >= :status_approved
 
         ORDER BY
                 latest_status.timecreated ASC,
-                status.timecreated ASC
+                signups_status.timecreated ASC
     ";
 
     $params = [

--- a/lib.php
+++ b/lib.php
@@ -1224,6 +1224,8 @@ function facetoface_get_attendees($sessionid) {
         AND ss.superceded != 1
         AND ss.statuscode >= ?
         ORDER BY
+            u.firstname,
+            u.lastname,
             sign.timecreated ASC,
             ss.timecreated ASC
     ", [$sessionid, MDL_F2F_STATUS_BOOKED, MDL_F2F_STATUS_WAITLISTED, $sessionid, MDL_F2F_STATUS_APPROVED]);
@@ -4677,7 +4679,7 @@ class facetoface_mycandidate_selector extends user_selector_base {
         $sql = "
               FROM  {user} u
                 $joinsstring
-              WHERE $where and
+              WHERE $where and 
                     u.suspended = 0 AND
                     u.id NOT IN
                     (

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023101908;
-$plugin->release   = 2023101908;
+$plugin->version   = 2023101907;
+$plugin->release   = 2023101907;
 $plugin->requires  = 2022031500;  // Requires 4.0.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023101907;
-$plugin->release   = 2023101907;
+$plugin->version   = 2023101908;
+$plugin->release   = 2023101908;
 $plugin->requires  = 2022031500;  // Requires 4.0.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
## Description:
The current waitlist logic in the Face-to-Face plugin uses a function that sorts attendees alphabetically by first and last name. This can lead to confusion, as the visual order does not reflect the actual order in which users signed up. This update introduces a new function that preserves the original behaviour while allowing for correct waitlist sequencing based on signup time.
### Added a new function: facetoface_get_attendees_by_signup used in facetoface_update_attendees function
- Based on the original facetoface_get_attendees function
- Uses signup timecreated for ordering
- Omits alphabetical sorting by firstname and lastname
### Maintained the original function to:
- Prevent regressions elsewhere in the codebase
- Ensure minimal risk of side effects

## Checklist before requesting a review:

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.

