### PR TITLE
GS-1060 f2 f admin bulk upload features are missing in site administration in moodle 4.5

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,8 +30,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025081802;
-$plugin->release   = 2025081802;
+$plugin->version   = 2025081801;
+$plugin->release   = 2025081801;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Restored 3 features in F2F:
- Bulk session uploading
- Admin bulk session uploading
- Admin bulk booking uploading

Added `settings.php` links and corrected method calls.
Unindented the body inside `if ($ADMIN->fulltree) { ... }` to avoid having 100+ lines of merge conflict in future Moodle upgrades.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [ ] Code has been commented, particularly in hard-to-understand areas.
- [ ] Required changes have been made to the documentation (excluding epic sub-issues).
- [x] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
Upload a CSV file for each of the 3 features. (Test cases exist in Zephyr when the 3 features were implemented)
