### PR TITLE
GS-1093: Quick fix: All three attendance statuses write to the databa…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2822,9 +2822,7 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                 $cminfo = cm_info::create($cm);
                 $custom = new \mod_facetoface\completion\custom_completion($cminfo, $record->userid);
 
-                if (
-                    $custom->get_state('completionattendance') === COMPLETION_COMPLETE
-                ) {
+                if ($custom->get_state('completionattendance') === COMPLETION_COMPLETE) {
                     // Get existing completion data, modify state, save, and update completion.
                     $data = $completion->get_data($cm, false, $record->userid);
                     $data->timemodified = $record->timefinish;

--- a/lib.php
+++ b/lib.php
@@ -2819,18 +2819,25 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
             $completion->update_state($cm, COMPLETION_UNKNOWN, $record->userid, false);
 
             if ($record->datetimeknown && get_config('facetoface', 'sessioncompletiondate')) {
-                // Get existing completion data, modify state, save, and update completion.
-                $data = $completion->get_data($cm, false, $record->userid);
-                $data->timemodified = $record->timefinish;
-                $completion->internal_set_data($cm, $data);
-                $completion->update_state($cm, COMPLETION_UNKNOWN, $record->userid, false);
+                $cminfo = cm_info::create($cm);
+                $custom = new \mod_facetoface\completion\custom_completion($cminfo, $record->userid);
 
-                // Update the course completion criteria entry.
-                $criteras = $completion->get_criteria(4); // 4 = completion_criteria_activity
-                foreach ($criteras as $criteria) {
-                    if ($criteria->module == 'facetoface' && $criteria->moduleinstance == $cm->id) {
-                        $criteriacompletion = $completion->get_user_completion($record->userid, $criteria);
-                        $criteriacompletion->mark_complete($record->timefinish);
+                if (
+                    $custom->get_state('completionattendance') === COMPLETION_COMPLETE
+                ) {
+                    // Get existing completion data, modify state, save, and update completion.
+                    $data = $completion->get_data($cm, false, $record->userid);
+                    $data->timemodified = $record->timefinish;
+                    $completion->internal_set_data($cm, $data);
+                    $completion->update_state($cm, COMPLETION_UNKNOWN, $record->userid, false);
+
+                    // Update the course completion criteria entry.
+                    $criteras = $completion->get_criteria(4); // 4 = completion_criteria_activity
+                    foreach ($criteras as $criteria) {
+                        if ($criteria->module == 'facetoface' && $criteria->moduleinstance == $cm->id) {
+                            $criteriacompletion = $completion->get_user_completion($record->userid, $criteria);
+                            $criteriacompletion->mark_complete($record->timefinish);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…se correctly.

## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Fixed the bug that when a user is marked as "No show" or "Partially attended" in a F2F session, a timestamp is written to `crit_comple_timecompleted`, `modules_completion.completionstate`, and `modules_completion.timemodified`.

After the fix, neither table is written with either "No show" or "Partially attended".
However, "Fully attended" correctly writes to both tables as well as `course_completions.timecompleted`

### Test Idea:
Use my Configurable_Report "Everything About Completions" to quickly view the latest entry in all completion-related tables. Please add a feature-request task if "Everything About Completions" misses some completion-related tables.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have **NOT** been updated.
- [ ] Code has been commented, particularly in hard-to-understand areas.
- [ ] Required changes have been made to the documentation (excluding epic sub-issues).
- [ ] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
