### PR TITLE
GS-683(restored): suppressemail tickbox persists after adding/removing attendees.

### DIFF
--- a/editattendees.php
+++ b/editattendees.php
@@ -217,7 +217,7 @@ if ($facetoface->signuptype == MOD_FACETOFACE_SIGNUP_MULTIPLE) {
     $table->data[] = new html_table_row([$cell]);
 }
 
-$content = html_writer::checkbox('suppressemail', 1, 0, get_string('suppressemail', 'facetoface'),
+$content = html_writer::checkbox('suppressemail', 1, $suppressemail, get_string('suppressemail', 'facetoface'),
     ['id' => 'suppressemail']);
 $content .= $OUTPUT->help_icon('suppressemail', 'facetoface');
 $cell = new html_table_cell($content);


### PR DESCRIPTION
The code was already reviewed in https://github.com/gchlol/moodle-mod_facetoface/pull/37 and merged into Moodle 4.1.

Commit 755b395ae73986364202f4ca399a9ac0673e41a4 was not merged into Moodle 4.5 due to some mistakes (along with the F2F bulk upload feature that has been fixed). This one has the same one-line change.

DD wants it. Preferably, we want to add this feature to 4.5 before DD upgrades at 6 AM, 2 Dec.

# Branching
## This branch (one-line code)
<img width="2387" height="609" alt="image" src="https://github.com/user-attachments/assets/760608f9-7320-409a-b895-644ac9da305c" />

## The original branch (Merged into 4.1 but somehow wasn't merged into 4.5)
<img width="2019" height="1273" alt="Untitled" src="https://github.com/user-attachments/assets/a4beea3f-df9e-4c9b-915d-7d3d747350f4" />
Version bump is likely not needed, but I'll quickly test it on SP.
