### PR TITLE
GS-1149: Corrected the course completion time to the session attendan…

### DIFF
--- a/classes/util/completion_util.php
+++ b/classes/util/completion_util.php
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+namespace mod_facetoface\util;
+
+use completion_completion;
+
 /**
  * External facetoface API.
  *
@@ -31,7 +35,6 @@ class completion_util {
      * @param int $user_id Target user ID.
      * @param int|null $time_started Optional `timestarted` to set if not already set. Defaults to now.
      * @return void
-     * @throws coding_exception
      */
     public static function recalculate_course_for_user(int $course_id, int $user_id, ?int $time_started = null): void {
         $completion = new completion_completion([

--- a/classes/util/completion_util.php
+++ b/classes/util/completion_util.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * External facetoface API.
+ *
+ * @package    mod_facetoface
+ * @copyright  2020 Gold Coast Health
+ * @author     Matthew Fein
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class completion_util {
+
+    /**
+     * Recalculate course completion for a given user.
+     *
+     * @param int $course_id Target course ID.
+     * @param int $user_id Target user ID.
+     * @param int|null $time_started Optional `timestarted` to set if not already set. Defaults to now.
+     * @return void
+     * @throws coding_exception
+     */
+    public static function recalculate_course_for_user(int $course_id, int $user_id, ?int $time_started = null): void {
+        $completion = new completion_completion([
+            'userid' => $user_id,
+            'course' => $course_id,
+        ]);
+
+        // Unset `timecompleted` to force reaggregation as set in `mark_inprogress()`.
+        $completion->timecompleted = null;
+        $completion->mark_inprogress($time_started);
+
+        // Trigger aggregation to instantly update course completion.
+        aggregate_completions($completion->id);
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -36,7 +36,7 @@ require_once($CFG->dirroot . '/lib/adminlib.php');
 require_once($CFG->dirroot . '/user/selector/lib.php');
 require_once($CFG->libdir . '/completionlib.php');
 
-use mod_signoff\util\completion_util;
+use mod_facetoface\util\completion_util;
 
 /*
  * Definitions for setting notification types.

--- a/lib.php
+++ b/lib.php
@@ -2840,7 +2840,7 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                         }
                     }
 
-                    // Update the course completion entry.
+                    // GCHLOL - YZ - Update the course completion entry.
                     completion_util::recalculate_course_for_user($course->id, $record->userid);
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -2840,19 +2840,8 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                         }
                     }
 
-                    // Ensure course completion time matches the latest criterion completion time.
-                    $maxcriteria = (int)$DB->get_field_sql(
-                    "
-                            SELECT MAX(timecompleted)
-                            FROM {course_completion_crit_compl}
-                            WHERE course = ? AND userid = ?
-                        ",
-                        [$course->id, $record->userid]
-                    );
-
-                    if ($maxcriteria) {
-                        completion_util::recalculate_course_for_user($course->id, $record->userid, $maxcriteria);
-                    }
+                    // Update the course completion entry.
+                    completion_util::recalculate_course_for_user($course->id, $record->userid);
                 }
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -36,6 +36,8 @@ require_once($CFG->dirroot . '/lib/adminlib.php');
 require_once($CFG->dirroot . '/user/selector/lib.php');
 require_once($CFG->libdir . '/completionlib.php');
 
+use mod_signoff\util\completion_util;
+
 /*
  * Definitions for setting notification types.
  */
@@ -2849,32 +2851,7 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                     );
 
                     if ($maxcriteria) {
-                        $coursecompletion = $DB->get_record(
-                            'course_completions',
-                            [
-                                'course' => $course->id,
-                                'userid' => $record->userid,
-                            ]
-                        );
-
-                        // Only adjust if the course is complete (row exists and timecompleted is set).
-                        if (
-                            $coursecompletion &&
-                            !empty($coursecompletion->timecompleted) &&
-                            (int)$coursecompletion->timecompleted !== $maxcriteria
-                        ) {
-
-                            $coursecompletion->timecompleted = $maxcriteria;
-                            $coursecompletion->timemodified = time();
-
-                            $DB->update_record('course_completions', $coursecompletion);
-                        }
-
-                        // Invalidate Moodle's cache for course completion for this user+course,
-                        // so that the course completion reports reflect the updated timecompleted immediately.
-                        $coursecompletioncache = cache::make('core', 'coursecompletion');
-                        $cachekey = $record->userid . '_' . $course->id;
-                        $coursecompletioncache->delete($cachekey);
+                        completion_util::recalculate_course_for_user($course->id, $record->userid, $maxcriteria);
                     }
                 }
             }

--- a/lib.php
+++ b/lib.php
@@ -2837,6 +2837,45 @@ function facetoface_take_individual_attendance($submissionid, $grading) {
                             $criteriacompletion->mark_complete($record->timefinish);
                         }
                     }
+
+                    // Ensure course completion time matches the latest criterion completion time.
+                    $maxcriteria = (int)$DB->get_field_sql(
+                    "
+                            SELECT MAX(timecompleted)
+                            FROM {course_completion_crit_compl}
+                            WHERE course = ? AND userid = ?
+                        ",
+                        [$course->id, $record->userid]
+                    );
+
+                    if ($maxcriteria) {
+                        $coursecompletion = $DB->get_record(
+                            'course_completions',
+                            [
+                                'course' => $course->id,
+                                'userid' => $record->userid,
+                            ]
+                        );
+
+                        // Only adjust if the course is complete (row exists and timecompleted is set).
+                        if (
+                            $coursecompletion &&
+                            !empty($coursecompletion->timecompleted) &&
+                            (int)$coursecompletion->timecompleted !== $maxcriteria
+                        ) {
+
+                            $coursecompletion->timecompleted = $maxcriteria;
+                            $coursecompletion->timemodified = time();
+
+                            $DB->update_record('course_completions', $coursecompletion);
+                        }
+
+                        // Invalidate Moodle's cache for course completion for this user+course,
+                        // so that the course completion reports reflect the updated timecompleted immediately.
+                        $coursecompletioncache = cache::make('core', 'coursecompletion');
+                        $cachekey = $record->userid . '_' . $course->id;
+                        $coursecompletioncache->delete($cachekey);
+                    }
                 }
             }
         }

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025103000.001;
+$plugin->version   = 2025103000.002;
 $plugin->release   = 2025103000;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Moodle's facetoface MOODLE_403_STABLE branch added the option to change activity completion to the session completion time, but they didn't also change the course completion time. The branch adds the latter immediately after Moodle's new code to change activity completion to the session completion time.


## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [ ] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
- [ ] Required changes have been made to the documentation (excluding epic sub-issues).
- [ ] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
