### PR TITLE
GS-1136: Show trainers from parent contexts instead of just the course

### DIFF
--- a/classes/session_form.php
+++ b/classes/session_form.php
@@ -169,30 +169,17 @@ class mod_facetoface_session_form extends moodleform {
                 $rolename = $rolename->name;
 
                 // Attempt to load users with this role in this course.
-                $usernamefields = facetoface_get_all_user_name_fields(true);
-                $rs = $DB->get_recordset_sql("
-                    SELECT
-                        u.id,
-                        {$usernamefields}
-                    FROM
-                        {role_assignments} ra
-                    LEFT JOIN
-                        {user} u
-                      ON ra.userid = u.id
-                    WHERE
-                        contextid = {$context->id}
-                    AND roleid = {$role}
-                ");
+                // GCHLOL: Change logic to pull users from parent contexts instead of just the course.
+                $roleusers = get_role_users($role, $context, true);
 
-                if (!$rs) {
+                if (empty($roleusers)) {
                     continue;
                 }
 
                 $choices = [];
-                foreach ($rs as $roleuser) {
+                foreach ($roleusers as $roleuser) {
                     $choices[$roleuser->id] = fullname($roleuser);
                 }
-                $rs->close();
 
                 // Show header (if haven't already).
                 if ($choices && !$headershown) {


### PR DESCRIPTION
## Description:
When adding a new session, the trainers shown are only the ones with the role within the course. This pull request changes the logic to pull users with the role from parent contexts (i.e. categories) as well.

## Checklist before requesting a review:
- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Code has been commented, particularly in hard-to-understand areas.
