### PR TITLE
Gs 1310 f2 f bulk session upload doesn t add to the calendar

### DIFF
--- a/classes/bulk_session_manager_parent.php
+++ b/classes/bulk_session_manager_parent.php
@@ -363,6 +363,8 @@ abstract class bulk_session_manager_parent {
     ): void {
         global $DB;
 
+        $errorcount = count($this->errors);
+
         $session->datetimeknown = 1;
         if (
             isset($record['Session Date/Time Known']) &&
@@ -509,6 +511,20 @@ abstract class bulk_session_manager_parent {
                 $this->errors[] = [
                     $index,
                     get_string('error:couldnotsavecustomfieldshort', 'facetoface', $shortname)
+                ];
+            }
+        }
+
+        // Only update the calendar if this row did not add any processing errors.
+        if (count($this->errors) === $errorcount) {
+            $calendarsession = facetoface_get_session($sessionid);
+            if ($calendarsession) {
+                facetoface_update_calendar_entries($calendarsession);
+
+            } else {
+                $this->errors[] = [
+                    $index,
+                    get_string('error:couldnotfindbulksession', 'facetoface')
                 ];
             }
         }

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -951,6 +951,7 @@ $string['error:invalidallowoverbook'] = 'Allow overbookings must be "yes" or "no
 $string['error:invaliddatetimedata'] = 'Invalid Date Time data.';
 $string['error:failedtocreatesession'] = 'Failed to create session';
 $string['error:failedtocreatedates'] = 'Failed to create dates for session #{$a}';
+$string['error:couldnotfindbulksession'] = 'Could not find the newly inserted bulk upload session';
 $string['error:couldnotsavecustomfieldshort'] = 'Could not save custom field with short name "{$a}"';
 $string['facetoface:uploadbulksessions'] = 'Bulk Upload Sessions';
 $string['uploadbulksessions'] = 'Upload sessions';

--- a/tests/calendar_event_test.php
+++ b/tests/calendar_event_test.php
@@ -160,6 +160,85 @@ class calendar_event_test extends \advanced_testcase {
     }
 
     /**
+     * Test that activity-level bulk session uploads create calendar events.
+     */
+    public function test_calendar_events_created_for_activity_level_bulk_upload(): void {
+        /** @var \mod_facetoface_generator $generator */
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
+
+        $course = $this->getDataGenerator()->create_course();
+        $facetoface = $generator->create_instance([
+            'course' => $course->id,
+            'showoncalendar' => F2F_CAL_COURSE,
+            'usercalentry' => 0,
+        ]);
+
+        $sessionmanager = new bulk_session_manager_activitylevel($facetoface->id);
+
+        $recordsproperty = new \ReflectionProperty(bulk_session_manager_parent::class, 'records');
+        $recordsproperty->setAccessible(true);
+        $recordsproperty->setValue($sessionmanager, [[
+            'Session Date/Time Known' => 'yes',
+            'Start Date' => '01/01/2030',
+            'Start Time' => '10:00',
+            'Finish Date' => '01/01/2030',
+            'Finish Time' => '11:00',
+            'Allow Cancellations' => 'yes',
+            'Capacity' => '10',
+            'Allow Overbookings' => 'no',
+            'Duration' => '60',
+            'Normal Cost' => '0',
+            'Discount Cost' => '0',
+            'Details' => 'Bulk upload session',
+        ]]);
+
+        $this->assertEmpty($sessionmanager->validate());
+        $this->assertTrue($sessionmanager->process());
+        $this->assert_events_count('session', 1);
+    }
+
+    /**
+     * Test that site-level bulk session uploads create calendar events.
+     */
+    public function test_calendar_events_created_for_site_level_bulk_upload(): void {
+        /** @var \mod_facetoface_generator $generator */
+        $generator = $this->getDataGenerator()->get_plugin_generator('mod_facetoface');
+
+        $course = $this->getDataGenerator()->create_course();
+        $facetoface = $generator->create_instance([
+            'course' => $course->id,
+            'name' => 'Bulk upload activity',
+            'showoncalendar' => F2F_CAL_SITE,
+            'usercalentry' => 0,
+        ]);
+
+        $sessionmanager = new bulk_session_manager_sitelevel();
+
+        $recordsproperty = new \ReflectionProperty(bulk_session_manager_parent::class, 'records');
+        $recordsproperty->setAccessible(true);
+        $recordsproperty->setValue($sessionmanager, [[
+            'Course Shortname' => $course->shortname,
+            'Face-to-Face Activity Name' => $facetoface->name,
+            'Session Date/Time Known' => 'yes',
+            'Start Date' => '01/01/2030',
+            'Start Time' => '10:00',
+            'Finish Date' => '01/01/2030',
+            'Finish Time' => '11:00',
+            'Allow Cancellations' => 'yes',
+            'Capacity' => '10',
+            'Allow Overbookings' => 'no',
+            'Duration' => '60',
+            'Normal Cost' => '0',
+            'Discount Cost' => '0',
+            'Details' => 'Bulk upload session',
+        ]]);
+
+        $this->assertEmpty($sessionmanager->validate());
+        $this->assertTrue($sessionmanager->process());
+        $this->assert_events_count('session', 1);
+    }
+
+    /**
      * Assert that counts for eventtype and sessionid match expected value.
      *
      * @param string $eventtype 'booking' or 'session'


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
1. Added the calendar events after either the course-level or the site-wide bulk session uploads.
It's very simple - since the `classes/bulk_session_manager_parent.php` is reused by both upload features, we only need to make a simple change in one place.
2. Added PHPUnit tests for a course-level or a site-wide bulk session uploads. I figured out how to pass unit tests on localhost.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have NOT been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
- [x] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
