### PR TITLE
[Hotfix] GS-1349: Send iCal email only; avoid sending another duplicate plain email

### DIFF
--- a/classes/booking_manager.php
+++ b/classes/booking_manager.php
@@ -405,7 +405,7 @@ class booking_manager {
             'ical' => MDL_F2F_ICAL,
             'icalendar' => MDL_F2F_ICAL,
             'both' => MDL_F2F_BOTH,
-            '' => MDL_F2F_BOTH, // Defaults to sending both if nothing is specified.
+            '' => MDL_F2F_ICAL, // Defaults to iCalendar only if nothing is specified.
         ];
 
         return $mapping[strtolower($type)] ?? null;

--- a/classes/booking_manager_bulk_attendance.php
+++ b/classes/booking_manager_bulk_attendance.php
@@ -403,7 +403,7 @@ class booking_manager_bulk_attendance {
             'ical' => MDL_F2F_ICAL,
             'icalendar' => MDL_F2F_ICAL,
             'both' => MDL_F2F_BOTH,
-            '' => MDL_F2F_BOTH, // Defaults to sending both if nothing is specified.
+            '' => MDL_F2F_ICAL, // Defaults to iCalendar only if nothing is specified.
         ];
 
         return $mapping[strtolower($type)] ?? null;

--- a/editattendees.php
+++ b/editattendees.php
@@ -131,7 +131,7 @@ if (optional_param('add', false, PARAM_BOOL) && confirm_sesskey()) {
                     } else {
                         $status = MDL_F2F_STATUS_WAITLISTED;
                     }
-                    if (!facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_BOTH,
+                    if (!facetoface_user_signup($session, $facetoface, $course, '', MDL_F2F_ICAL,
                             $status, $adduser, !$suppressemail)) {
                         $erruser = $DB->get_record('user', ['id' => $adduser], "id, {$usernamefields}");
                         $errors[] = get_string('error:addattendee', 'facetoface', fullname($erruser));

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -243,7 +243,7 @@ Fields expected:
 - Email address (required)
 - Session number (required)
 - Discount code (optional)
-- Notification type (optional - valid options are 'email', 'ical', or 'both')
+- Notification type (optional - valid options are 'email', 'ical', or 'both'; blank defaults to 'ical')
 ";
 
 $string['facetoface:uploadandpreview'] = 'Upload and validate bookings';
@@ -881,7 +881,7 @@ Fields expected:
 - Session number (required)
 - Status (optional - valid options are cancelled,  booked, waitlisted, no_show, partially_attended, and fully_attended)
 - Discount code (optional)
-- Notification type (optional - valid options are 'email', 'ical', or 'both')
+- Notification type (optional - valid options are 'email', 'ical', or 'both'; blank defaults to 'ical')
 ";
 $string['facetoface:editsessions'] = 'Add, edit and copy Face-to-face sessions';
 
@@ -999,7 +999,7 @@ $string['facetoface:uploadbookingsextfiledesc'] = "
 Fields expected:
 - Session ID (required)
 - Status (optional - valid options are cancelled,  booked, waitlisted, no_show, partially_attended, and fully_attended)
-- Notification type (optional - valid options are 'email', 'ical', or 'both')";
+- Notification type (optional - valid options are 'email', 'ical', or 'both'; blank defaults to 'ical')";
 $string['examplecsvfilename'] = 'example_bookings.csv';
 $string['uploadbulkattendance'] = 'Upload bookings';
 $string['error:activitydoesnotexist'] = 'Face-to-Face activity not found: {$a}';
@@ -1009,7 +1009,7 @@ $string['csvuploadhelp:status'] = 'Status';
 $string['csvuploadhelp:statustype'] = 'For now, only use "booked"';
 $string['csvuploadhelp:discountcode'] = 'Discount Code';
 $string['csvuploadhelp:notificationtype'] = 'Notification Type';
-$string['csvuploadhelp:oneofnotif'] = 'One of: email, ical, both';
+$string['csvuploadhelp:oneofnotif'] = 'One of: email, ical, both. Blank defaults to ical.';
 $string['uploadandpreviewbulkbookings'] = 'Upload and preview bookings';
 $string['uploadbulkbookingsfile'] = 'Bulk Bookings File';
 $string['bulkattendanceprocessed'] = 'Bulk bookings have been successfully processed.';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Only send one iCal email instead of also another duplicated plain one when a student is enrolled in F2F session.

Also fixed the default option for bulk bookings.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have NOT been updated.
- [x] Any new test cases have been created and existing test cases updated (excluding epic sub-issues).
