### PR TITLE
GS-1215 F2F bulk upload bookings overrides the original session finish time

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2256,19 +2256,28 @@ function facetoface_update_signup_status($signupid, $statuscode, $createdby, $no
     $timenow = time();
 
     // GCHLOL: PB - Use the session finish time as the marked-off time for attendance statuses.
-    $sql = "SELECT DISTINCT fsd.timefinish
-              FROM {facetoface_sessions_dates} fsd
-              JOIN {facetoface_signups} fs
-                ON fs.sessionid = fsd.sessionid AND fs.id = ?";
+    $sessiontimes = $timenow;
 
-    $sessiontime = $DB->get_record_sql($sql, array($signupid));
-    if ($statuscode == MDL_F2F_STATUS_NO_SHOW
-            OR $statuscode == MDL_F2F_STATUS_PARTIALLY_ATTENDED
-            OR $statuscode == MDL_F2F_STATUS_FULLY_ATTENDED) {
+    $sessionfinishsql = "
+        SELECT DISTINCT
+                sessions_dates.timefinish
+
+        FROM    {facetoface_sessions_dates} sessions_dates
+                JOIN {facetoface_signups} signups ON
+                    signups.sessionid = sessions_dates.sessionid AND
+                    signups.id = ?
+    ";
+
+    $sessiontime = $DB->get_record_sql($sessionfinishsql, array($signupid));
+
+    if (
+        $statuscode == MDL_F2F_STATUS_NO_SHOW OR
+        $statuscode == MDL_F2F_STATUS_PARTIALLY_ATTENDED OR
+        $statuscode == MDL_F2F_STATUS_FULLY_ATTENDED
+    ) {
         $sessiontimes = $sessiontime->timefinish;
-    } else {
-        $sessiontimes = $timenow;
     }
+    // GCHLOL ends.
 
     $signupstatus = new stdclass;
     $signupstatus->signupid = $signupid;

--- a/lib.php
+++ b/lib.php
@@ -2255,11 +2255,26 @@ function facetoface_update_signup_status($signupid, $statuscode, $createdby, $no
     global $DB;
     $timenow = time();
 
+    // GCHLOL: PB - Use the session finish time as the marked-off time for attendance statuses.
+    $sql = "SELECT DISTINCT fsd.timefinish
+              FROM {facetoface_sessions_dates} fsd
+              JOIN {facetoface_signups} fs
+                ON fs.sessionid = fsd.sessionid AND fs.id = ?";
+
+    $sessiontime = $DB->get_record_sql($sql, array($signupid));
+    if ($statuscode == MDL_F2F_STATUS_NO_SHOW
+            OR $statuscode == MDL_F2F_STATUS_PARTIALLY_ATTENDED
+            OR $statuscode == MDL_F2F_STATUS_FULLY_ATTENDED) {
+        $sessiontimes = $sessiontime->timefinish;
+    } else {
+        $sessiontimes = $timenow;
+    }
+
     $signupstatus = new stdclass;
     $signupstatus->signupid = $signupid;
     $signupstatus->statuscode = $statuscode;
     $signupstatus->createdby = $createdby;
-    $signupstatus->timecreated = $timenow;
+    $signupstatus->timecreated = $sessiontimes; // GCHLOL: PB change from $timenow to $sessiontimes.
     $signupstatus->note = $note;
     $signupstatus->grade = $grade;
     $signupstatus->superceded = 0;


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Restored Peter's feature to use the session finish timestamp as the marked-off time when bulk-uploading bookings.

This feature was deleted after the 4.5 Moodle upgrade, and the Moodle default is the current time.

## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have NOT been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
