### PR TITLE
GS-1251 Reimplement Session Date Format

### DIFF
--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -898,8 +898,8 @@ $string['error:nopermissiontoeditattendees'] = 'You don\'t have permission to ed
 $string['facetoface:deletesessions'] = 'Delete Face-to-face sessions';
 
 // Core
-$string['session:strftimedate'] = '';
-$string['session:strftimetime'] = '';
+$string['session:strftimedate'] = '%d %B %Y';
+$string['session:strftimetime'] = '%I:%M %p';
 
 // Pages
 $string['attendees:print'] = 'Print';

--- a/lang/en/facetoface.php
+++ b/lang/en/facetoface.php
@@ -900,6 +900,7 @@ $string['facetoface:deletesessions'] = 'Delete Face-to-face sessions';
 // Core
 $string['session:strftimedate'] = '%d %B %Y';
 $string['session:strftimetime'] = '%I:%M %p';
+$string['session:strftimedatetime'] = '%d %B %Y, %I:%M %p';
 
 // Pages
 $string['attendees:print'] = 'Print';

--- a/lib.php
+++ b/lib.php
@@ -2912,12 +2912,13 @@ function facetoface_format_session_times($start, $end, $tz) {
         $targettz = core_date::get_user_timezone($tz);
     }
 
-    $formattedsession->startdate = userdate($start, get_string('strftimedate', 'langconfig'), $targettz);
-    $formattedsession->startdatetime = userdate($start, get_string('strftimedatetime', 'langconfig'), $targettz);
-    $formattedsession->starttime = userdate($start, get_string('strftimetime', 'langconfig'), $targettz);
-    $formattedsession->enddate = userdate($end, get_string('strftimedate', 'langconfig'), $targettz);
-    $formattedsession->enddatetime = userdate($end, get_string('strftimedatetime', 'langconfig'), $targettz);
-    $formattedsession->endtime = userdate($end, get_string('strftimetime', 'langconfig'), $targettz);
+    // GCHLOL NL: Use facetoface session specific strings instead of global.
+    $formattedsession->startdate = userdate($start, get_string('session:strftimedate', 'facetoface'), $targettz);
+    $formattedsession->startdatetime = userdate($start, get_string('session:strftimedatetime', 'facetoface'), $targettz);
+    $formattedsession->starttime = userdate($start, get_string('session:strftimetime', 'facetoface'), $targettz);
+    $formattedsession->enddate = userdate($end, get_string('session:strftimedate', 'facetoface'), $targettz);
+    $formattedsession->enddatetime = userdate($end, get_string('session:strftimedatetime', 'facetoface'), $targettz);
+    $formattedsession->endtime = userdate($end, get_string('session:strftimetime', 'facetoface'), $targettz);
     if (empty($displaytimezones)) {
         $formattedsession->timezone = '';
     } else {

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025103000.002;
+$plugin->version   = 2025103000.003;
 $plugin->release   = 2025103000;
 $plugin->requires  = 2023100900;  // Requires 4.3.
 $plugin->component = 'mod_facetoface';


### PR DESCRIPTION
## Description:
<!-- Describe your changes in detail / numbered list of distinct changes for reference -->
Reimplements the changes originally done in #7 although with a more limited scope due to upstream modernisation and string defaults to avoid needing to dynamically switch between core and plugin based strings.

Example: Updating the `session:strftimedate` and `session:strftimedatetime` strings to have an added `%A` at the start e.g. `%A %d %B %Y` will add the day of week to session date outputs. This applies to both the sessions list and attendance sheet as below.

<img width="711" height="141" alt="image" src="https://github.com/user-attachments/assets/98489f34-60dd-4545-ba84-ccc7c26f21b5" />
<img width="349" height="139" alt="image" src="https://github.com/user-attachments/assets/0e7d23b3-8627-408d-97f1-0fafde0cdb87" />


## Checklist before requesting a review:
<!-- Remove non-applicable items e.g. epic sub-issue points -->
<!-- Add an 'x' inside the brackets to check the item -->

- [x] I have performed a self review of my code.
- [x] My code follows the [Moodle Coding Style](https://moodledev.io/general/development/policies/codingstyle).
- [x] Version numbers have been updated.
- [x] Code has been commented, particularly in hard-to-understand areas.
